### PR TITLE
The perlvar is $^O not $^0

### DIFF
--- a/gnu/usr.bin/perl/lib/locale.t
+++ b/gnu/usr.bin/perl/lib/locale.t
@@ -592,7 +592,7 @@ if (-x "/usr/bin/locale" && open(LOCALES, "/usr/bin/locale -a 2>/dev/null|")) {
         trylocale($_);
     }
     close(LOCALES);
-} elsif (($^O eq 'openbsd' || $^0 eq 'bitrig' ) && -e '/usr/share/locale') {
+} elsif (($^O eq 'openbsd' || $^O eq 'bitrig' ) && -e '/usr/share/locale') {
 
    # OpenBSD doesn't have a locale executable, so reading /usr/share/locale
    # is much easier and faster than the last resort method.


### PR DESCRIPTION
$^0 is not a valid perlvar, the OS name variable is $^O.
