### PR TITLE
Remove arbitrary element limit from ksh arrays.

### DIFF
--- a/bin/ksh/ksh.1
+++ b/bin/ksh/ksh.1
@@ -1038,7 +1038,6 @@ form
 where
 .Ar expr
 is an arithmetic expression.
-Array indices are currently limited to the range 0 through 10239, inclusive.
 Parameter substitutions take the form
 .Pf $ Ns Ar name ,
 .Pf ${ Ns Ar name Ns } ,

--- a/bin/ksh/sh.h
+++ b/bin/ksh/sh.h
@@ -68,7 +68,6 @@ typedef INT32 Tflag;
 
 #define	LINE	2048		/* input line size */
 #define	PATH	1024		/* pathname size (todo: PATH_MAX/pathconf()) */
-#define ARRAYMAX (10*1024-1)	/* max array index */
 
 EXTERN	const char *kshname;	/* $0 */
 EXTERN	pid_t	kshpid;		/* $$, shell pid */

--- a/bin/ksh/var.c
+++ b/bin/ksh/var.c
@@ -142,7 +142,7 @@ array_index_calc(const char *n, bool *arrayp, int *valp)
 		afree(tmp, ATEMP);
 		n = str_nsave(n, p - n, ATEMP);
 		evaluate(sub, &rval, KSH_UNWIND_ERROR, true);
-		if (rval < 0 || rval > ARRAYMAX)
+		if (rval < 0)
 			errorf("%s: subscript %ld out of range", n, rval);
 		*valp = rval;
 		afree(sub, ATEMP);


### PR DESCRIPTION
ARRAYMAX seems to have survived from a time where arrays where
preallocated.
