### PR TITLE
Added option to remove sourceless firmware

### DIFF
--- a/distrib/miniroot/install.sub
+++ b/distrib/miniroot/install.sub
@@ -1415,7 +1415,6 @@ install_http() {
 	_file_list=$(ftp -Vo - "$_url_base/index.txt" |
 		sed 's/^.* //' | sed 's///')
 
-
 	install_files "$_url_base" "$_file_list"
 
 	# Remember where we installed from, to tell the cgi server.


### PR DESCRIPTION
At the moment, this just empties /etc/firmware. If any open source firmware is added in the future, this will need to be changed
