### PR TITLE
Import recent virtio changes from OpenBSD

### DIFF
--- a/sys/arch/amd64/include/atomic.h
+++ b/sys/arch/amd64/include/atomic.h
@@ -339,23 +339,6 @@ atomic_sub_long(volatile long *p, unsigned long v)
 	atomic_sub_64((volatile int64_t *)p, v);
 }
 
-
-/*
- * The AMD64 architecture is rather strongly ordered.  When accessing
- * normal write-back cachable memory, only reads may be reordered with
- * older writes to different locations.  There are a few instructions
- * (clfush, non-temporal move instructions) that obey weaker ordering
- * rules, but those instructions will only be used in (inline)
- * assembly code where we can add the necessary fence instructions
- * ourselves.
- */
-#define __membar(_f) do { __asm __volatile(_f ::: "memory"); } while (0)
-
-/* virtio needs MP membars even on SP kernels */
-#define virtio_membar_producer()	__membar("")
-#define virtio_membar_consumer()	__membar("")
-#define virtio_membar_sync()		__membar("mfence")
-
 #undef LOCK
 
 #endif /* defined(_KERNEL) && !defined(_LOCORE) */

--- a/sys/dev/pci/virtio.c
+++ b/sys/dev/pci/virtio.c
@@ -657,7 +657,7 @@ publish_avail_idx(struct virtio_softc *sc, struct virtqueue *vq)
 {
 	vq_sync_aring(sc, vq, BUS_DMASYNC_PREWRITE);
 
-	virtio_membar_producer();
+	atomic_thread_fence(memory_order_release);
 	vq->vq_avail->idx = vq->vq_avail_idx;
 	vq_sync_aring(sc, vq, BUS_DMASYNC_POSTWRITE);
 	vq->vq_queued = 1;
@@ -688,14 +688,14 @@ notify:
 			uint16_t t;
 			publish_avail_idx(sc, vq);
 
-			virtio_membar_sync();
+			atomic_thread_fence(memory_order_seq_cst);
 			t = VQ_AVAIL_EVENT(vq) + 1;
 			if ((uint16_t)(n - t) < (uint16_t)(n - o))
 				sc->sc_ops->kick(sc, vq->vq_index);
 		} else {
 			publish_avail_idx(sc, vq);
 
-			virtio_membar_sync();
+			atomic_thread_fence(memory_order_seq_cst);
 			if (!(vq->vq_used->flags & VRING_USED_F_NO_NOTIFY))
 				sc->sc_ops->kick(sc, vq->vq_index);
 		}
@@ -749,7 +749,7 @@ virtio_dequeue(struct virtio_softc *sc, struct virtqueue *vq,
 	usedidx = vq->vq_used_idx++;
 	usedidx &= vq->vq_mask;
 
-	virtio_membar_consumer();
+	atomic_thread_fence(memory_order_acquire);
 	slot = vq->vq_used->ring[usedidx].id;
 	qe = &vq->vq_entries[slot];
 
@@ -800,7 +800,7 @@ virtio_postpone_intr(struct virtqueue *vq, uint16_t nslots)
 
 	/* set the new event index: avail_ring->used_event = idx */
 	VQ_USED_EVENT(vq) = idx;
-	virtio_membar_sync();
+	atomic_thread_fence(memory_order_seq_cst);
 
 	vq_sync_aring(vq->vq_owner, vq, BUS_DMASYNC_PREWRITE);
 	vq->vq_queued++;
@@ -875,7 +875,7 @@ virtio_start_vq_intr(struct virtio_softc *sc, struct virtqueue *vq)
 	else
 		vq->vq_avail->flags &= ~VRING_AVAIL_F_NO_INTERRUPT;
 
-	virtio_membar_sync();
+	atomic_thread_fence(memory_order_seq_cst);
 
 	vq_sync_aring(sc, vq, BUS_DMASYNC_PREWRITE);
 	vq->vq_queued++;


### PR DESCRIPTION
This pull request imports recent virtio changes, fixing memory synchronization issues.

We probably won't want to use virtio_membar_\* macros which use the membar API. I have replaced them with C11 atomics. I have left it unsquashed so one can have a look and compare, to see that I have used the correct atomics.
