### PR TITLE
arm: drain the write buffer on every pte sync

### DIFF
--- a/sys/arch/arm/include/pmap.h
+++ b/sys/arch/arm/include/pmap.h
@@ -328,9 +328,9 @@ extern int pmap_needs_pte_sync;
 
 #define	PTE_SYNC(pte)							\
 do {									\
+	cpu_drain_writebuf();						\
 	if (PMAP_NEEDS_PTE_SYNC) {					\
 		paddr_t pa;						\
-		cpu_drain_writebuf();					\
 		cpu_dcache_wb_range((vaddr_t)(pte), sizeof(pt_entry_t));\
 		if (cpu_sdcache_enabled()) { 				\
 		(void)pmap_extract(pmap_kernel(), (vaddr_t)(pte), &pa);	\
@@ -343,9 +343,9 @@ do {									\
 
 #define	PTE_SYNC_RANGE(pte, cnt)					\
 do {									\
+	cpu_drain_writebuf();						\
 	if (PMAP_NEEDS_PTE_SYNC) {					\
 		paddr_t pa;						\
-		cpu_drain_writebuf();					\
 		cpu_dcache_wb_range((vaddr_t)(pte),			\
 		    (cnt) << 2); /* * sizeof(pt_entry_t) */		\
 		if (cpu_sdcache_enabled()) { 				\


### PR DESCRIPTION
Currently we keep the pagetables uncached.  This means that we
don't need to take care of flushing the L1- and L2-Caches when
we change something there.  But what we forgot is that the write
buffer has to be emptied manually if we want to make sure the
changes get to the memory as soon as possible.

What happens at the moment is that when we change something in
the pagetables, we do not make sure it hits memory ASAP.

Therefore, drain the writebuf every time we call PTE_SYNC.

This fixes the issues seen when trying to boot Allwinner A20
based systems.
