### PR TITLE
Consistently use COMPILER_RT_ABI for all public symbols.

### DIFF
--- a/contrib/compiler-rt/lib/absvti2.c
+++ b/contrib/compiler-rt/lib/absvti2.c
@@ -20,7 +20,7 @@
 
 /* Effects: aborts if abs(x) < 0 */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __absvti2(ti_int a)
 {
     const int N = (int)(sizeof(ti_int) * CHAR_BIT);

--- a/contrib/compiler-rt/lib/addsf3.c
+++ b/contrib/compiler-rt/lib/addsf3.c
@@ -17,7 +17,8 @@
 
 ARM_EABI_FNALIAS(fadd, addsf3)
 
-fp_t __addsf3(fp_t a, fp_t b) {
+COMPILER_RT_ABI fp_t
+__addsf3(fp_t a, fp_t b) {
 
     rep_t aRep = toRep(a);
     rep_t bRep = toRep(b);

--- a/contrib/compiler-rt/lib/addvti3.c
+++ b/contrib/compiler-rt/lib/addvti3.c
@@ -20,7 +20,7 @@
 
 /* Effects: aborts if a + b overflows */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __addvti3(ti_int a, ti_int b)
 {
     ti_int s = a + b;

--- a/contrib/compiler-rt/lib/ashlti3.c
+++ b/contrib/compiler-rt/lib/ashlti3.c
@@ -20,7 +20,7 @@
 
 /* Precondition:  0 <= b < bits_in_tword */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __ashlti3(ti_int a, si_int b)
 {
     const int bits_in_dword = (int)(sizeof(di_int) * CHAR_BIT);

--- a/contrib/compiler-rt/lib/ashrti3.c
+++ b/contrib/compiler-rt/lib/ashrti3.c
@@ -20,7 +20,7 @@
 
 /* Precondition:  0 <= b < bits_in_tword */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __ashrti3(ti_int a, si_int b)
 {
     const int bits_in_dword = (int)(sizeof(di_int) * CHAR_BIT);

--- a/contrib/compiler-rt/lib/clzti2.c
+++ b/contrib/compiler-rt/lib/clzti2.c
@@ -20,7 +20,7 @@
 
 /* Precondition: a != 0 */
 
-si_int
+COMPILER_RT_ABI si_int
 __clzti2(ti_int a)
 {
     twords x;

--- a/contrib/compiler-rt/lib/cmpti2.c
+++ b/contrib/compiler-rt/lib/cmpti2.c
@@ -21,7 +21,7 @@
  *           if (a >  b) returns 2
  */
 
-si_int
+COMPILER_RT_ABI si_int
 __cmpti2(ti_int a, ti_int b)
 {
     twords x;

--- a/contrib/compiler-rt/lib/comparedf2.c
+++ b/contrib/compiler-rt/lib/comparedf2.c
@@ -47,7 +47,8 @@ enum LE_RESULT {
     LE_UNORDERED =  1
 };
 
-enum LE_RESULT __ledf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum LE_RESULT
+__ledf2(fp_t a, fp_t b) {
     
     const srep_t aInt = toRep(a);
     const srep_t bInt = toRep(b);
@@ -86,7 +87,8 @@ enum GE_RESULT {
     GE_UNORDERED = -1   // Note: different from LE_UNORDERED
 };
 
-enum GE_RESULT __gedf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum GE_RESULT
+__gedf2(fp_t a, fp_t b) {
     
     const srep_t aInt = toRep(a);
     const srep_t bInt = toRep(b);
@@ -106,7 +108,8 @@ enum GE_RESULT __gedf2(fp_t a, fp_t b) {
     }
 }
 
-int __unorddf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI int
+__unorddf2(fp_t a, fp_t b) {
     const rep_t aAbs = toRep(a) & absMask;
     const rep_t bAbs = toRep(b) & absMask;
     return aAbs > infRep || bAbs > infRep;
@@ -114,19 +117,23 @@ int __unorddf2(fp_t a, fp_t b) {
 
 // The following are alternative names for the preceeding routines.
 
-enum LE_RESULT __eqdf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum LE_RESULT
+__eqdf2(fp_t a, fp_t b) {
     return __ledf2(a, b);
 }
 
-enum LE_RESULT __ltdf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum LE_RESULT
+__ltdf2(fp_t a, fp_t b) {
     return __ledf2(a, b);
 }
 
-enum LE_RESULT __nedf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum LE_RESULT
+__nedf2(fp_t a, fp_t b) {
     return __ledf2(a, b);
 }
 
-enum GE_RESULT __gtdf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum GE_RESULT
+__gtdf2(fp_t a, fp_t b) {
     return __gedf2(a, b);
 }
 

--- a/contrib/compiler-rt/lib/comparesf2.c
+++ b/contrib/compiler-rt/lib/comparesf2.c
@@ -47,7 +47,8 @@ enum LE_RESULT {
     LE_UNORDERED =  1
 };
 
-enum LE_RESULT __lesf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum LE_RESULT
+__lesf2(fp_t a, fp_t b) {
     
     const srep_t aInt = toRep(a);
     const srep_t bInt = toRep(b);
@@ -86,7 +87,8 @@ enum GE_RESULT {
     GE_UNORDERED = -1   // Note: different from LE_UNORDERED
 };
 
-enum GE_RESULT __gesf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum GE_RESULT
+__gesf2(fp_t a, fp_t b) {
     
     const srep_t aInt = toRep(a);
     const srep_t bInt = toRep(b);
@@ -106,7 +108,8 @@ enum GE_RESULT __gesf2(fp_t a, fp_t b) {
     }
 }
 
-int __unordsf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI int
+__unordsf2(fp_t a, fp_t b) {
     const rep_t aAbs = toRep(a) & absMask;
     const rep_t bAbs = toRep(b) & absMask;
     return aAbs > infRep || bAbs > infRep;
@@ -114,18 +117,22 @@ int __unordsf2(fp_t a, fp_t b) {
 
 // The following are alternative names for the preceeding routines.
 
-enum LE_RESULT __eqsf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum LE_RESULT
+__eqsf2(fp_t a, fp_t b) {
     return __lesf2(a, b);
 }
 
-enum LE_RESULT __ltsf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum LE_RESULT
+__ltsf2(fp_t a, fp_t b) {
     return __lesf2(a, b);
 }
 
-enum LE_RESULT __nesf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum LE_RESULT
+__nesf2(fp_t a, fp_t b) {
     return __lesf2(a, b);
 }
 
-enum GE_RESULT __gtsf2(fp_t a, fp_t b) {
+COMPILER_RT_ABI enum GE_RESULT
+__gtsf2(fp_t a, fp_t b) {
     return __gesf2(a, b);
 }

--- a/contrib/compiler-rt/lib/ctzti2.c
+++ b/contrib/compiler-rt/lib/ctzti2.c
@@ -20,7 +20,7 @@
 
 /* Precondition: a != 0 */
 
-si_int
+COMPILER_RT_ABI si_int
 __ctzti2(ti_int a)
 {
     twords x;

--- a/contrib/compiler-rt/lib/divdc3.c
+++ b/contrib/compiler-rt/lib/divdc3.c
@@ -17,7 +17,7 @@
 
 /* Returns: the quotient of (a + ib) / (c + id) */
 
-double _Complex
+COMPILER_RT_ABI double _Complex
 __divdc3(double __a, double __b, double __c, double __d)
 {
     int __ilogbw = 0;

--- a/contrib/compiler-rt/lib/divdf3.c
+++ b/contrib/compiler-rt/lib/divdf3.c
@@ -21,7 +21,8 @@
 
 ARM_EABI_FNALIAS(ddiv, divdf3)
 
-fp_t __divdf3(fp_t a, fp_t b) {
+COMPILER_RT_ABI fp_t
+__divdf3(fp_t a, fp_t b) {
     
     const unsigned int aExponent = toRep(a) >> significandBits & maxExponent;
     const unsigned int bExponent = toRep(b) >> significandBits & maxExponent;

--- a/contrib/compiler-rt/lib/divdi3.c
+++ b/contrib/compiler-rt/lib/divdi3.c
@@ -14,8 +14,6 @@
 
 #include "int_lib.h"
 
-du_int COMPILER_RT_ABI __udivmoddi4(du_int a, du_int b, du_int* rem);
-
 /* Returns: a / b */
 
 COMPILER_RT_ABI di_int

--- a/contrib/compiler-rt/lib/divmoddi4.c
+++ b/contrib/compiler-rt/lib/divmoddi4.c
@@ -14,8 +14,6 @@
 
 #include "int_lib.h"
 
-extern COMPILER_RT_ABI di_int __divdi3(di_int a, di_int b);
-
 /* Returns: a / b, *rem = a % b  */
 
 COMPILER_RT_ABI di_int

--- a/contrib/compiler-rt/lib/divmodsi4.c
+++ b/contrib/compiler-rt/lib/divmodsi4.c
@@ -14,9 +14,6 @@
 
 #include "int_lib.h"
 
-extern COMPILER_RT_ABI si_int __divsi3(si_int a, si_int b);
-
-
 /* Returns: a / b, *rem = a % b  */
 
 COMPILER_RT_ABI si_int

--- a/contrib/compiler-rt/lib/divsc3.c
+++ b/contrib/compiler-rt/lib/divsc3.c
@@ -17,7 +17,7 @@
 
 /* Returns: the quotient of (a + ib) / (c + id) */
 
-float _Complex
+COMPILER_RT_ABI float _Complex
 __divsc3(float __a, float __b, float __c, float __d)
 {
     int __ilogbw = 0;

--- a/contrib/compiler-rt/lib/divsf3.c
+++ b/contrib/compiler-rt/lib/divsf3.c
@@ -21,7 +21,8 @@
 
 ARM_EABI_FNALIAS(fdiv, divsf3)
 
-fp_t __divsf3(fp_t a, fp_t b) {
+COMPILER_RT_ABI fp_t
+__divsf3(fp_t a, fp_t b) {
     
     const unsigned int aExponent = toRep(a) >> significandBits & maxExponent;
     const unsigned int bExponent = toRep(b) >> significandBits & maxExponent;

--- a/contrib/compiler-rt/lib/divsi3.c
+++ b/contrib/compiler-rt/lib/divsi3.c
@@ -14,8 +14,6 @@
 
 #include "int_lib.h"
 
-su_int COMPILER_RT_ABI __udivsi3(su_int n, su_int d);
-
 /* Returns: a / b */
 
 ARM_EABI_FNALIAS(idiv, divsi3)

--- a/contrib/compiler-rt/lib/divti3.c
+++ b/contrib/compiler-rt/lib/divti3.c
@@ -16,11 +16,9 @@
 
 #if __x86_64
 
-tu_int __udivmodti4(tu_int a, tu_int b, tu_int* rem);
-
 /* Returns: a / b */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __divti3(ti_int a, ti_int b)
 {
     const int bits_in_tword_m1 = (int)(sizeof(ti_int) * CHAR_BIT) - 1;

--- a/contrib/compiler-rt/lib/divxc3.c
+++ b/contrib/compiler-rt/lib/divxc3.c
@@ -18,7 +18,7 @@
 
 /* Returns: the quotient of (a + ib) / (c + id) */
 
-long double _Complex
+COMPILER_RT_ABI long double _Complex
 __divxc3(long double __a, long double __b, long double __c, long double __d)
 {
     int __ilogbw = 0;

--- a/contrib/compiler-rt/lib/enable_execute_stack.c
+++ b/contrib/compiler-rt/lib/enable_execute_stack.c
@@ -36,7 +36,8 @@
  * that means changing the protection on those page(s) to rwx. 
  */
 
-void __enable_execute_stack(void* addr)
+COMPILER_RT_ABI void
+__enable_execute_stack(void* addr)
 {
 
 #if __APPLE__
@@ -55,5 +56,3 @@ void __enable_execute_stack(void* addr)
 	size_t length = endPage - startPage;
 	(void) mprotect((void *)startPage, length, PROT_READ | PROT_WRITE | PROT_EXEC);
 }
-
-

--- a/contrib/compiler-rt/lib/eprintf.c
+++ b/contrib/compiler-rt/lib/eprintf.c
@@ -25,8 +25,9 @@
 #ifndef _WIN32
 __attribute__((visibility("hidden")))
 #endif
-void __eprintf(const char* format, const char* assertion_expression,
-				const char* line, const char* file)
+COMPILER_RT_ABI void
+__eprintf(const char* format, const char* assertion_expression,
+	  const char* line, const char* file)
 {
 	fprintf(stderr, format, assertion_expression, line, file);
 	fflush(stderr);

--- a/contrib/compiler-rt/lib/extendsfdf2.c
+++ b/contrib/compiler-rt/lib/extendsfdf2.c
@@ -68,7 +68,8 @@ static inline dst_t dstFromRep(dst_rep_t x) {
 
 ARM_EABI_FNALIAS(f2d, extendsfdf2)
 
-dst_t __extendsfdf2(src_t a) {
+COMPILER_RT_ABI dst_t
+__extendsfdf2(src_t a) {
     
     // Various constants whose values follow from the type parameters.
     // Any reasonable optimizer will fold and propagate all of these.

--- a/contrib/compiler-rt/lib/ffsti2.c
+++ b/contrib/compiler-rt/lib/ffsti2.c
@@ -20,7 +20,7 @@
  * the value zero if a is zero. The least significant bit is index one.
  */
 
-si_int
+COMPILER_RT_ABI si_int
 __ffsti2(ti_int a)
 {
     twords x;

--- a/contrib/compiler-rt/lib/fixdfdi.c
+++ b/contrib/compiler-rt/lib/fixdfdi.c
@@ -25,7 +25,7 @@
 
 ARM_EABI_FNALIAS(d2lz, fixdfdi)
 
-di_int
+COMPILER_RT_ABI di_int
 __fixdfdi(double a)
 {
     double_bits fb;

--- a/contrib/compiler-rt/lib/fixdfsi.c
+++ b/contrib/compiler-rt/lib/fixdfsi.c
@@ -20,7 +20,8 @@
 
 ARM_EABI_FNALIAS(d2iz, fixdfsi)
 
-int __fixdfsi(fp_t a) {
+COMPILER_RT_ABI int
+__fixdfsi(fp_t a) {
     
     // Break a into sign, exponent, significand
     const rep_t aRep = toRep(a);

--- a/contrib/compiler-rt/lib/fixdfti.c
+++ b/contrib/compiler-rt/lib/fixdfti.c
@@ -25,7 +25,7 @@
 
 /* seee eeee eeee mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __fixdfti(double a)
 {
     double_bits fb;

--- a/contrib/compiler-rt/lib/fixsfti.c
+++ b/contrib/compiler-rt/lib/fixsfti.c
@@ -25,7 +25,7 @@
 
 /* seee eeee emmm mmmm mmmm mmmm mmmm mmmm */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __fixsfti(float a)
 {
     float_bits fb;

--- a/contrib/compiler-rt/lib/fixunsdfti.c
+++ b/contrib/compiler-rt/lib/fixunsdfti.c
@@ -28,7 +28,7 @@
 
 /* seee eeee eeee mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm */
 
-tu_int
+COMPILER_RT_ABI tu_int
 __fixunsdfti(double a)
 {
     double_bits fb;

--- a/contrib/compiler-rt/lib/fixunssfti.c
+++ b/contrib/compiler-rt/lib/fixunssfti.c
@@ -28,7 +28,7 @@
 
 /* seee eeee emmm mmmm mmmm mmmm mmmm mmmm */
 
-tu_int
+COMPILER_RT_ABI tu_int
 __fixunssfti(float a)
 {
     float_bits fb;

--- a/contrib/compiler-rt/lib/fixunsxfdi.c
+++ b/contrib/compiler-rt/lib/fixunsxfdi.c
@@ -30,7 +30,7 @@
  * 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm
  */
 
-du_int
+COMPILER_RT_ABI du_int
 __fixunsxfdi(long double a)
 {
     long_double_bits fb;

--- a/contrib/compiler-rt/lib/fixunsxfsi.c
+++ b/contrib/compiler-rt/lib/fixunsxfsi.c
@@ -30,7 +30,7 @@
  * 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm
  */
 
-su_int
+COMPILER_RT_ABI su_int
 __fixunsxfsi(long double a)
 {
     long_double_bits fb;

--- a/contrib/compiler-rt/lib/fixunsxfti.c
+++ b/contrib/compiler-rt/lib/fixunsxfti.c
@@ -30,7 +30,7 @@
  * 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm
  */
 
-tu_int
+COMPILER_RT_ABI tu_int
 __fixunsxfti(long double a)
 {
     long_double_bits fb;

--- a/contrib/compiler-rt/lib/fixxfdi.c
+++ b/contrib/compiler-rt/lib/fixxfdi.c
@@ -27,7 +27,7 @@
  * 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm
  */
 
-di_int
+COMPILER_RT_ABI di_int
 __fixxfdi(long double a)
 {
     long_double_bits fb;

--- a/contrib/compiler-rt/lib/fixxfti.c
+++ b/contrib/compiler-rt/lib/fixxfti.c
@@ -27,7 +27,7 @@
  * 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm
  */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __fixxfti(long double a)
 {
     long_double_bits fb;

--- a/contrib/compiler-rt/lib/floatdixf.c
+++ b/contrib/compiler-rt/lib/floatdixf.c
@@ -26,7 +26,7 @@
  * 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm
  */
 
-long double
+COMPILER_RT_ABI long double
 __floatdixf(di_int a)
 {
     if (a == 0)

--- a/contrib/compiler-rt/lib/floatsidf.c
+++ b/contrib/compiler-rt/lib/floatsidf.c
@@ -20,7 +20,8 @@
 
 ARM_EABI_FNALIAS(i2d, floatsidf)
 
-fp_t __floatsidf(int a) {
+COMPILER_RT_ABI fp_t
+__floatsidf(int a) {
     
     const int aWidth = sizeof a * CHAR_BIT;
     

--- a/contrib/compiler-rt/lib/floatsisf.c
+++ b/contrib/compiler-rt/lib/floatsisf.c
@@ -20,7 +20,8 @@
 
 ARM_EABI_FNALIAS(i2f, floatsisf)
 
-fp_t __floatsisf(int a) {
+COMPILER_RT_ABI fp_t
+__floatsisf(int a) {
     
     const int aWidth = sizeof a * CHAR_BIT;
     

--- a/contrib/compiler-rt/lib/floattidf.c
+++ b/contrib/compiler-rt/lib/floattidf.c
@@ -24,9 +24,7 @@
 
 /* seee eeee eeee mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm */ 
 
-si_int __clzti2(ti_int a);
-
-double
+COMPILER_RT_ABI double
 __floattidf(ti_int a)
 {
     if (a == 0)

--- a/contrib/compiler-rt/lib/floattisf.c
+++ b/contrib/compiler-rt/lib/floattisf.c
@@ -24,9 +24,7 @@
 
 /* seee eeee emmm mmmm mmmm mmmm mmmm mmmm */
 
-si_int __clzti2(ti_int a);
-
-float
+COMPILER_RT_ABI float
 __floattisf(ti_int a)
 {
     if (a == 0)

--- a/contrib/compiler-rt/lib/floattixf.c
+++ b/contrib/compiler-rt/lib/floattixf.c
@@ -26,9 +26,7 @@
  * 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm
  */
 
-si_int __clzti2(ti_int a);
-
-long double
+COMPILER_RT_ABI long double
 __floattixf(ti_int a)
 {
     if (a == 0)

--- a/contrib/compiler-rt/lib/floatundidf.c
+++ b/contrib/compiler-rt/lib/floatundidf.c
@@ -29,7 +29,6 @@ ARM_EABI_FNALIAS(ul2d, floatundidf)
  * as a side-effect of this computation.
  */
 
-
 COMPILER_RT_ABI double
 __floatundidf(du_int a)
 {

--- a/contrib/compiler-rt/lib/floatundixf.c
+++ b/contrib/compiler-rt/lib/floatundixf.c
@@ -25,7 +25,7 @@
 /* gggg gggg gggg gggg gggg gggg gggg gggg | gggg gggg gggg gggg seee eeee eeee eeee |
  * 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm
  */
-long double
+COMPILER_RT_ABI long double
 __floatundixf(du_int a)
 {
     if (a == 0)

--- a/contrib/compiler-rt/lib/floatunsidf.c
+++ b/contrib/compiler-rt/lib/floatunsidf.c
@@ -20,7 +20,8 @@
 
 ARM_EABI_FNALIAS(ui2d, floatunsidf)
 
-fp_t __floatunsidf(unsigned int a) {
+COMPILER_RT_ABI fp_t
+__floatunsidf(unsigned int a) {
     
     const int aWidth = sizeof a * CHAR_BIT;
     

--- a/contrib/compiler-rt/lib/floatunsisf.c
+++ b/contrib/compiler-rt/lib/floatunsisf.c
@@ -20,7 +20,8 @@
 
 ARM_EABI_FNALIAS(ui2f, floatunsisf)
 
-fp_t __floatunsisf(unsigned int a) {
+COMPILER_RT_ABI fp_t
+__floatunsisf(unsigned int a) {
     
     const int aWidth = sizeof a * CHAR_BIT;
     

--- a/contrib/compiler-rt/lib/floatuntidf.c
+++ b/contrib/compiler-rt/lib/floatuntidf.c
@@ -24,9 +24,7 @@
 
 /* seee eeee eeee mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm */
 
-si_int __clzti2(ti_int a);
-
-double
+COMPILER_RT_ABI double
 __floatuntidf(tu_int a)
 {
     if (a == 0)

--- a/contrib/compiler-rt/lib/floatuntisf.c
+++ b/contrib/compiler-rt/lib/floatuntisf.c
@@ -24,9 +24,7 @@
 
 /* seee eeee emmm mmmm mmmm mmmm mmmm mmmm */
 
-si_int __clzti2(ti_int a);
-
-float
+COMPILER_RT_ABI float
 __floatuntisf(tu_int a)
 {
     if (a == 0)

--- a/contrib/compiler-rt/lib/floatuntixf.c
+++ b/contrib/compiler-rt/lib/floatuntixf.c
@@ -26,9 +26,7 @@
  * 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm
  */
 
-si_int __clzti2(ti_int a);
-
-long double
+COMPILER_RT_ABI long double
 __floatuntixf(tu_int a)
 {
     if (a == 0)

--- a/contrib/compiler-rt/lib/fp_lib.h
+++ b/contrib/compiler-rt/lib/fp_lib.h
@@ -141,4 +141,7 @@ static inline void wideRightShiftWithSticky(rep_t *hi, rep_t *lo, unsigned int c
     }
 }
 
+COMPILER_RT_ABI fp_t __adddf3(fp_t a, fp_t b);
+COMPILER_RT_ABI fp_t __addsf3(fp_t a, fp_t b);
+
 #endif // FP_LIB_HEADER

--- a/contrib/compiler-rt/lib/gcc_personality_v0.c
+++ b/contrib/compiler-rt/lib/gcc_personality_v0.c
@@ -46,11 +46,11 @@ struct _Unwind_Exception {
     uintptr_t                private_2;    
 };
 
-extern const uint8_t*    _Unwind_GetLanguageSpecificData(_Unwind_Context_t c);
-extern void              _Unwind_SetGR(_Unwind_Context_t c, int i, uintptr_t n);
-extern void              _Unwind_SetIP(_Unwind_Context_t, uintptr_t new_value);
-extern uintptr_t         _Unwind_GetIP(_Unwind_Context_t context);
-extern uintptr_t         _Unwind_GetRegionStart(_Unwind_Context_t context);
+COMPILER_RT_ABI  const uint8_t*    _Unwind_GetLanguageSpecificData(_Unwind_Context_t c);
+COMPILER_RT_ABI  void              _Unwind_SetGR(_Unwind_Context_t c, int i, uintptr_t n);
+COMPILER_RT_ABI  void              _Unwind_SetIP(_Unwind_Context_t, uintptr_t new_value);
+COMPILER_RT_ABI  uintptr_t         _Unwind_GetIP(_Unwind_Context_t context);
+COMPILER_RT_ABI  uintptr_t         _Unwind_GetRegionStart(_Unwind_Context_t context);
 
 
 /*
@@ -182,11 +182,13 @@ static uintptr_t readEncodedPointer(const uint8_t** data, uint8_t encoding)
  */
 #if __arm__
 // the setjump-longjump based exceptions personality routine has a different name
-_Unwind_Reason_Code __gcc_personality_sj0(int version, _Unwind_Action actions,
+COMPILER_RT_ABI _Unwind_Reason_Code
+__gcc_personality_sj0(int version, _Unwind_Action actions,
          uint64_t exceptionClass, struct _Unwind_Exception* exceptionObject,
          _Unwind_Context_t context)
 #else
-_Unwind_Reason_Code __gcc_personality_v0(int version, _Unwind_Action actions,
+COMPILER_RT_ABI _Unwind_Reason_Code
+__gcc_personality_v0(int version, _Unwind_Action actions,
          uint64_t exceptionClass, struct _Unwind_Exception* exceptionObject,
          _Unwind_Context_t context)
 #endif

--- a/contrib/compiler-rt/lib/int_lib.h
+++ b/contrib/compiler-rt/lib/int_lib.h
@@ -51,6 +51,20 @@
 /* Include internal utility function declarations. */
 #include "int_util.h"
 
+COMPILER_RT_ABI si_int __paritysi2(si_int a);
+COMPILER_RT_ABI si_int __paritydi2(di_int a);
+
+COMPILER_RT_ABI di_int __divdi3(di_int a, di_int b);
+COMPILER_RT_ABI si_int __divsi3(si_int a, si_int b);
+COMPILER_RT_ABI su_int __udivsi3(su_int n, su_int d);
+
+COMPILER_RT_ABI su_int __udivmodsi4(su_int a, su_int b, su_int* rem);
+COMPILER_RT_ABI du_int __udivmoddi4(du_int a, du_int b, du_int* rem);
+#ifdef CRT_HAS_128BIT
+COMPILER_RT_ABI si_int __clzti2(ti_int a);
+COMPILER_RT_ABI tu_int __udivmodti4(tu_int a, tu_int b, tu_int* rem);
+#endif
+
 /*
  * Workaround for LLVM bug 11663.  Prevent endless recursion in
  * __c?zdi2(), where calls to __builtin_c?z() are expanded to

--- a/contrib/compiler-rt/lib/lshrti3.c
+++ b/contrib/compiler-rt/lib/lshrti3.c
@@ -20,7 +20,7 @@
 
 /* Precondition:  0 <= b < bits_in_tword */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __lshrti3(ti_int a, si_int b)
 {
     const int bits_in_dword = (int)(sizeof(di_int) * CHAR_BIT);

--- a/contrib/compiler-rt/lib/moddi3.c
+++ b/contrib/compiler-rt/lib/moddi3.c
@@ -14,8 +14,6 @@
 
 #include "int_lib.h"
 
-COMPILER_RT_ABI du_int __udivmoddi4(du_int a, du_int b, du_int* rem);
-
 /* Returns: a % b */
 
 COMPILER_RT_ABI di_int

--- a/contrib/compiler-rt/lib/modsi3.c
+++ b/contrib/compiler-rt/lib/modsi3.c
@@ -14,8 +14,6 @@
 
 #include "int_lib.h"
 
-su_int COMPILER_RT_ABI __divsi3(si_int a, si_int b);
-
 /* Returns: a % b */
 
 COMPILER_RT_ABI si_int

--- a/contrib/compiler-rt/lib/modti3.c
+++ b/contrib/compiler-rt/lib/modti3.c
@@ -16,11 +16,9 @@
 
 #if __x86_64
 
-tu_int __udivmodti4(tu_int a, tu_int b, tu_int* rem);
-
 /*Returns: a % b */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __modti3(ti_int a, ti_int b)
 {
     const int bits_in_tword_m1 = (int)(sizeof(ti_int) * CHAR_BIT) - 1;

--- a/contrib/compiler-rt/lib/muldc3.c
+++ b/contrib/compiler-rt/lib/muldc3.c
@@ -17,7 +17,7 @@
 
 /* Returns: the product of a + ib and c + id */
 
-double _Complex
+COMPILER_RT_ABI double _Complex
 __muldc3(double __a, double __b, double __c, double __d)
 {
     double __ac = __a * __c;

--- a/contrib/compiler-rt/lib/mulodi4.c
+++ b/contrib/compiler-rt/lib/mulodi4.c
@@ -18,7 +18,7 @@
 
 /* Effects: sets *overflow to 1  if a * b overflows */
 
-di_int
+COMPILER_RT_ABI di_int
 __mulodi4(di_int a, di_int b, int* overflow)
 {
     const int N = (int)(sizeof(di_int) * CHAR_BIT);

--- a/contrib/compiler-rt/lib/mulosi4.c
+++ b/contrib/compiler-rt/lib/mulosi4.c
@@ -18,7 +18,7 @@
 
 /* Effects: sets *overflow to 1  if a * b overflows */
 
-si_int
+COMPILER_RT_ABI si_int
 __mulosi4(si_int a, si_int b, int* overflow)
 {
     const int N = (int)(sizeof(si_int) * CHAR_BIT);

--- a/contrib/compiler-rt/lib/muloti4.c
+++ b/contrib/compiler-rt/lib/muloti4.c
@@ -20,7 +20,7 @@
 
 /* Effects: sets *overflow to 1  if a * b overflows */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __muloti4(ti_int a, ti_int b, int* overflow)
 {
     const int N = (int)(sizeof(ti_int) * CHAR_BIT);

--- a/contrib/compiler-rt/lib/mulsc3.c
+++ b/contrib/compiler-rt/lib/mulsc3.c
@@ -17,7 +17,7 @@
 
 /* Returns: the product of a + ib and c + id */
 
-float _Complex
+COMPILER_RT_ABI float _Complex
 __mulsc3(float __a, float __b, float __c, float __d)
 {
     float __ac = __a * __c;

--- a/contrib/compiler-rt/lib/multi3.c
+++ b/contrib/compiler-rt/lib/multi3.c
@@ -42,7 +42,7 @@ __mulddi3(du_int a, du_int b)
 
 /* Returns: a * b */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __multi3(ti_int a, ti_int b)
 {
     twords x;

--- a/contrib/compiler-rt/lib/mulvdi3.c
+++ b/contrib/compiler-rt/lib/mulvdi3.c
@@ -18,7 +18,7 @@
 
 /* Effects: aborts if a * b overflows */
 
-di_int
+COMPILER_RT_ABI di_int
 __mulvdi3(di_int a, di_int b)
 {
     const int N = (int)(sizeof(di_int) * CHAR_BIT);

--- a/contrib/compiler-rt/lib/mulvsi3.c
+++ b/contrib/compiler-rt/lib/mulvsi3.c
@@ -18,7 +18,7 @@
 
 /* Effects: aborts if a * b overflows */
 
-si_int
+COMPILER_RT_ABI si_int
 __mulvsi3(si_int a, si_int b)
 {
     const int N = (int)(sizeof(si_int) * CHAR_BIT);

--- a/contrib/compiler-rt/lib/mulvti3.c
+++ b/contrib/compiler-rt/lib/mulvti3.c
@@ -20,7 +20,7 @@
 
 /* Effects: aborts if a * b overflows */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __mulvti3(ti_int a, ti_int b)
 {
     const int N = (int)(sizeof(ti_int) * CHAR_BIT);

--- a/contrib/compiler-rt/lib/mulxc3.c
+++ b/contrib/compiler-rt/lib/mulxc3.c
@@ -19,7 +19,7 @@
 
 /* Returns: the product of a + ib and c + id */
 
-long double _Complex
+COMPILER_RT_ABI long double _Complex
 __mulxc3(long double __a, long double __b, long double __c, long double __d)
 {
     long double __ac = __a * __c;

--- a/contrib/compiler-rt/lib/negdf2.c
+++ b/contrib/compiler-rt/lib/negdf2.c
@@ -16,6 +16,7 @@
 
 ARM_EABI_FNALIAS(dneg, negdf2)
 
-fp_t __negdf2(fp_t a) {
+COMPILER_RT_ABI fp_t
+__negdf2(fp_t a) {
     return fromRep(toRep(a) ^ signBit);
 }

--- a/contrib/compiler-rt/lib/negdi2.c
+++ b/contrib/compiler-rt/lib/negdi2.c
@@ -16,7 +16,7 @@
 
 /* Returns: -a */
 
-di_int
+COMPILER_RT_ABI di_int
 __negdi2(di_int a)
 {
     /* Note: this routine is here for API compatibility; any sane compiler

--- a/contrib/compiler-rt/lib/negti2.c
+++ b/contrib/compiler-rt/lib/negti2.c
@@ -18,7 +18,7 @@
 
 /* Returns: -a */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __negti2(ti_int a)
 {
     /* Note: this routine is here for API compatibility; any sane compiler

--- a/contrib/compiler-rt/lib/negvti2.c
+++ b/contrib/compiler-rt/lib/negvti2.c
@@ -20,7 +20,7 @@
 
 /* Effects: aborts if -a overflows */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __negvti2(ti_int a)
 {
     const ti_int MIN = (ti_int)1 << ((int)(sizeof(ti_int) * CHAR_BIT)-1);

--- a/contrib/compiler-rt/lib/paritydi2.c
+++ b/contrib/compiler-rt/lib/paritydi2.c
@@ -16,8 +16,6 @@
 
 /* Returns: 1 if number of bits is odd else returns 0 */
 
-si_int COMPILER_RT_ABI __paritysi2(si_int a);
-
 COMPILER_RT_ABI si_int
 __paritydi2(di_int a)
 {

--- a/contrib/compiler-rt/lib/parityti2.c
+++ b/contrib/compiler-rt/lib/parityti2.c
@@ -18,9 +18,7 @@
 
 /* Returns: 1 if number of bits is odd else returns 0 */
 
-si_int __paritydi2(di_int a);
-
-si_int
+COMPILER_RT_ABI si_int
 __parityti2(ti_int a)
 {
     twords x;

--- a/contrib/compiler-rt/lib/popcountti2.c
+++ b/contrib/compiler-rt/lib/popcountti2.c
@@ -18,7 +18,7 @@
 
 /* Returns: count of 1 bits */
 
-si_int
+COMPILER_RT_ABI si_int
 __popcountti2(ti_int a)
 {
     tu_int x3 = (tu_int)a;

--- a/contrib/compiler-rt/lib/powitf2.c
+++ b/contrib/compiler-rt/lib/powitf2.c
@@ -18,7 +18,7 @@
 
 /* Returns: a ^ b */
 
-long double
+COMPILER_RT_ABI long double
 __powitf2(long double a, si_int b)
 {
     const int recip = b < 0;

--- a/contrib/compiler-rt/lib/powixf2.c
+++ b/contrib/compiler-rt/lib/powixf2.c
@@ -18,7 +18,7 @@
 
 /* Returns: a ^ b */
 
-long double
+COMPILER_RT_ABI long double
 __powixf2(long double a, si_int b)
 {
     const int recip = b < 0;

--- a/contrib/compiler-rt/lib/subdf3.c
+++ b/contrib/compiler-rt/lib/subdf3.c
@@ -15,9 +15,6 @@
 #define DOUBLE_PRECISION
 #include "fp_lib.h"
 
-fp_t COMPILER_RT_ABI __adddf3(fp_t a, fp_t b);
-
-
 ARM_EABI_FNALIAS(dsub, subdf3)
 
 // Subtraction; flip the sign bit of b and add.

--- a/contrib/compiler-rt/lib/subsf3.c
+++ b/contrib/compiler-rt/lib/subsf3.c
@@ -15,8 +15,6 @@
 #define SINGLE_PRECISION
 #include "fp_lib.h"
 
-fp_t COMPILER_RT_ABI __addsf3(fp_t a, fp_t b);
-
 ARM_EABI_FNALIAS(fsub, subsf3)
 
 // Subtraction; flip the sign bit of b and add.

--- a/contrib/compiler-rt/lib/subvti3.c
+++ b/contrib/compiler-rt/lib/subvti3.c
@@ -20,7 +20,7 @@
 
 /* Effects: aborts if a - b overflows */
 
-ti_int
+COMPILER_RT_ABI ti_int
 __subvti3(ti_int a, ti_int b)
 {
     ti_int s = a - b;

--- a/contrib/compiler-rt/lib/trampoline_setup.c
+++ b/contrib/compiler-rt/lib/trampoline_setup.c
@@ -21,8 +21,9 @@ extern void __clear_cache(void* start, void* end);
  */
 
 #if __ppc__ && !defined(__powerpc64__)
-void __trampoline_setup(uint32_t* trampOnStack, int trampSizeAllocated, 
-                                const void* realFunc, void* localsPtr)
+COMPILER_RT_ABI void
+__trampoline_setup(uint32_t* trampOnStack, int trampSizeAllocated, 
+                   const void* realFunc, void* localsPtr)
 {
     /* should never happen, but if compiler did not allocate */
     /* enough space on stack for the trampoline, abort */

--- a/contrib/compiler-rt/lib/ucmpti2.c
+++ b/contrib/compiler-rt/lib/ucmpti2.c
@@ -21,7 +21,7 @@
  *           if (a >  b) returns 2
  */
 
-si_int
+COMPILER_RT_ABI si_int
 __ucmpti2(tu_int a, tu_int b)
 {
     utwords x;

--- a/contrib/compiler-rt/lib/udivdi3.c
+++ b/contrib/compiler-rt/lib/udivdi3.c
@@ -14,8 +14,6 @@
 
 #include "int_lib.h"
 
-du_int COMPILER_RT_ABI __udivmoddi4(du_int a, du_int b, du_int* rem);
-
 /* Returns: a / b */
 
 COMPILER_RT_ABI du_int

--- a/contrib/compiler-rt/lib/udivmodsi4.c
+++ b/contrib/compiler-rt/lib/udivmodsi4.c
@@ -14,9 +14,6 @@
 
 #include "int_lib.h"
 
-extern su_int COMPILER_RT_ABI __udivsi3(su_int n, su_int d);
-
-
 /* Returns: a / b, *rem = a % b  */
 
 COMPILER_RT_ABI su_int

--- a/contrib/compiler-rt/lib/udivmodti4.c
+++ b/contrib/compiler-rt/lib/udivmodti4.c
@@ -22,7 +22,7 @@
 
 /* Translated from Figure 3-40 of The PowerPC Compiler Writer's Guide */
 
-tu_int
+COMPILER_RT_ABI tu_int
 __udivmodti4(tu_int a, tu_int b, tu_int* rem)
 {
     const unsigned n_udword_bits = sizeof(du_int) * CHAR_BIT;

--- a/contrib/compiler-rt/lib/udivti3.c
+++ b/contrib/compiler-rt/lib/udivti3.c
@@ -16,11 +16,9 @@
 
 #if __x86_64
 
-tu_int __udivmodti4(tu_int a, tu_int b, tu_int* rem);
-
 /* Returns: a / b */
 
-tu_int
+COMPILER_RT_ABI tu_int
 __udivti3(tu_int a, tu_int b)
 {
     return __udivmodti4(a, b, 0);

--- a/contrib/compiler-rt/lib/umoddi3.c
+++ b/contrib/compiler-rt/lib/umoddi3.c
@@ -14,8 +14,6 @@
 
 #include "int_lib.h"
 
-du_int COMPILER_RT_ABI __udivmoddi4(du_int a, du_int b, du_int* rem);
-
 /* Returns: a % b */
 
 COMPILER_RT_ABI du_int

--- a/contrib/compiler-rt/lib/umodsi3.c
+++ b/contrib/compiler-rt/lib/umodsi3.c
@@ -16,8 +16,6 @@
 
 /* Returns: a % b */
 
-su_int COMPILER_RT_ABI __udivsi3(su_int a, su_int b);
-
 COMPILER_RT_ABI su_int
 __umodsi3(su_int a, su_int b)
 {

--- a/contrib/compiler-rt/lib/umodti3.c
+++ b/contrib/compiler-rt/lib/umodti3.c
@@ -16,11 +16,9 @@
 
 #if __x86_64
 
-tu_int __udivmodti4(tu_int a, tu_int b, tu_int* rem);
-
 /* Returns: a % b */
 
-tu_int
+COMPILER_RT_ABI tu_int
 __umodti3(tu_int a, tu_int b)
 {
     tu_int r;


### PR DESCRIPTION
Move prototypes into headers and fix a few inconsistencies.

Imported as in bfbb8bbc8e4a4fce3538aa85b095543fee291df7.
Applied cleanly, although the path to the files changed.

ae87ccaedad6737817cd296824b56615fb5f1556 is also needed
and included.

clear cache changed according to 76a80b1b277c477cd1a2fbee4f9b024bb1bc56c6
and 8554b6b336c08d813b59a4f2383e31b22f30e4dd.
