### PR TITLE
sysmerge checksums have to be in the etc set

### DIFF
--- a/distrib/sets/lists/base/mi
+++ b/distrib/sets/lists/base/mi
@@ -10847,8 +10847,6 @@
 ./usr/share/snmp/mibs/OPENBSD-SENSORS-MIB.txt
 ./usr/share/snmp/mibs/OPENBSD-SNMPD-CONF.txt
 ./usr/share/sysmerge
-./usr/share/sysmerge/etcsum
-./usr/share/sysmerge/examplessum
 ./usr/share/tabset
 ./usr/share/tabset/std
 ./usr/share/tabset/stdcrt

--- a/distrib/sets/lists/etc/mi
+++ b/distrib/sets/lists/etc/mi
@@ -155,6 +155,8 @@
 ./root/.cshrc
 ./root/.login
 ./root/.profile
+./usr/share/sysmerge/etcsum
+./usr/share/sysmerge/examplessum
 ./var/crash/minfree
 ./var/cron/at.deny
 ./var/cron/cron.deny


### PR DESCRIPTION
This fixes that sysmerge doesn't currently work.
