### PR TITLE
Create a new sysctl to hide processes not owned by a user unless you are root

### DIFF
--- a/lib/libc/gen/sysctl.3
+++ b/lib/libc/gen/sysctl.3
@@ -475,6 +475,7 @@ information.
 .It Dv KERN_USERMOUNT Ta "integer" Ta "yes"
 .It Dv KERN_VERSION Ta "string" Ta "no"
 .It Dv KERN_WATCHDOG Ta "node" Ta "not applicable"
+.It Dv KERN_HIDEPROC Ta "integer" Ta "yes"
 .El
 .Bl -tag -width "123456"
 .It Dv KERN_ARGMAX
@@ -1082,6 +1083,9 @@ variable.
 .It Dv KERN_WATCHDOG_PERIOD
 The period of the watchdog timer in seconds.
 Set to 0 to disable the watchdog timer.
+.It Dv KERN_HIDEPROC
+If set to 1, the kernel will only list processes belonging to the user
+making the call, except if the user is root.
 .El
 .El
 .Ss CTL_MACHDEP

--- a/sbin/sysctl/sysctl.8
+++ b/sbin/sysctl/sysctl.8
@@ -197,6 +197,7 @@ and a few require a kernel compiled with non-standard
 .It kern.maxlocksperuid Ta integer Ta yes
 .It kern.bufcachepercent Ta integer Ta yes
 .It kern.consdev Ta string Ta no
+.It kern.hideproc Ta integer Ta yes
 .It kern.global_ptrace Ta integer Ta yes
 .It kern.chroot_mknod Ta integer Ta no
 .It vm.vmmeter Ta struct Ta no

--- a/sys/sys/sysctl.h
+++ b/sys/sys/sysctl.h
@@ -184,7 +184,8 @@ struct ctlname {
 #define	KERN_GLOBAL_PTRACE	81	/* allow ptrace globally */
 /* gap for Bitrig */
 #define	KERN_CHROOTMKNOD	100	/* allow mknod in chroot */
-#define	KERN_MAXID		101	/* number of valid kern ids */
+#define KERN_HIDEPROC		101	/* int: system hide other procs */
+#define	KERN_MAXID		102	/* number of valid kern ids */
 
 #define	CTL_KERN_NAMES { \
 	{ 0, 0 }, \
@@ -288,6 +289,7 @@ struct ctlname {
 	{ "gap", 0 }, \
 	{ "gap", 0 }, \
 	{ "chroot_mknod", CTLTYPE_INT }, \
+	{ "hideproc", CTLTYPE_INT }, \
 }
 
 /*


### PR DESCRIPTION
I wrote a patch which adds a new kernel sysctl (hideproc) to hide processes non owned by a user, except for root. This should be mostly useful on shell servers and on servers with chroots.
