### PR TITLE
adding necessary changes facilitate building auto-install ramdisks

### DIFF
--- a/distrib/amd64/ramdisk/Makefile
+++ b/distrib/amd64/ramdisk/Makefile
@@ -4,7 +4,7 @@ REV=		${OSrev}
 IMAGE=		mr.fs
 CBIN?=		instbin
 CRUNCHCONF?=	${CBIN}.conf
-LISTS=		${.CURDIR}/list
+LISTS=		${.CURDIR}/list ${.CURDIR}/list.local
 UTILS?=		${.CURDIR}/../../miniroot
 
 FSDIR=		${.OBJDIR}/fs

--- a/distrib/amd64/ramdisk/list.local
+++ b/distrib/amd64/ramdisk/list.local
@@ -1,0 +1,8 @@
+# add any site local files to include in the ramdisk here
+#
+# To make an automatic install ramdisk, first create a file called
+# auto_install.conf in the same directory as this file and uncomment the line
+# below. The contents and format of auto_install.conf is documented in the
+# AUTOINSTALL(8) man page.
+#
+# COPY  ${CURDIR}/auto_install.conf     auto_install.conf


### PR DESCRIPTION
This adds the hooks and example necessary to add site local files to a ramdisk.  The most obvious reason to do this is to create auto-install ramdisks.  I'm using it to build auto-install cd images for use with gitian to do deterministic builds of bitrig.