### PR TITLE
cp: implement -x option

### DIFF
--- a/bin/cp/cp.1
+++ b/bin/cp/cp.1
@@ -43,14 +43,14 @@
 .Nm cp
 .Op Fl fipv
 .Oo
-.Fl R
+.Fl Rx
 .Op Fl H | L | P
 .Oc
 .Ar source target
 .Nm cp
 .Op Fl fipv
 .Oo
-.Fl R
+.Fl Rx
 .Op Fl H | L | P
 .Oc
 .Ar source ... directory
@@ -149,6 +149,8 @@ instead.
 Causes
 .Nm
 to be verbose, showing files as they are copied.
+.It Fl x
+Do not cross mount points when copying recursively.
 .El
 .Pp
 For each destination file that already exists, its contents are
@@ -239,9 +241,9 @@ utility is compliant with the
 .St -p1003.1-2008
 specification.
 .Pp
-The flag
-.Op Fl v
-is an extension to that specification.
+The flags
+.Op Fl vx
+are an extension to that specification.
 .Pp
 Historic versions of the
 .Nm

--- a/bin/cp/cp.c
+++ b/bin/cp/cp.c
@@ -72,7 +72,7 @@
 PATH_T to = { to.p_path, "" };
 
 uid_t myuid;
-int Rflag, fflag, iflag, pflag, rflag, vflag;
+int Rflag, fflag, iflag, pflag, rflag, vflag, xflag;
 mode_t myumask;
 
 enum op { FILE_TO_FILE, FILE_TO_DIR, DIR_TO_DNE };
@@ -90,8 +90,8 @@ main(int argc, char *argv[])
 
 	(void)setlocale(LC_ALL, "");
 
-	Hflag = Lflag = Pflag = Rflag = 0;
-	while ((ch = getopt(argc, argv, "HLPRfiprv")) != -1)
+	Hflag = Lflag = Pflag = Rflag = xflag = 0;
+	while ((ch = getopt(argc, argv, "HLPRfiprvx")) != -1)
 		switch (ch) {
 		case 'H':
 			Hflag = 1;
@@ -125,6 +125,9 @@ main(int argc, char *argv[])
 		case 'v':
 			vflag = 1;
 			break;
+		case 'x':
+			xflag = 1;
+			break;
 		default:
 			usage();
 			break;
@@ -136,6 +139,8 @@ main(int argc, char *argv[])
 		usage();
 
 	fts_options = FTS_NOCHDIR | FTS_PHYSICAL;
+	if (xflag)
+		fts_options = FTS_XDEV;
 	if (rflag) {
 		if (Rflag)
 			errx(1,

--- a/bin/cp/utils.c
+++ b/bin/cp/utils.c
@@ -318,9 +318,9 @@ void
 usage(void)
 {
 	(void)fprintf(stderr,
-	    "usage: %s [-fip] [-R [-H | -L | -P]] source target\n", __progname);
+	    "usage: %s [-fipx] [-R [-H | -L | -P]] source target\n", __progname);
 	(void)fprintf(stderr,
-	    "       %s [-fip] [-R [-H | -L | -P]] source ... directory\n",
+	    "       %s [-fipx] [-R [-H | -L | -P]] source ... directory\n",
 	    __progname);
 	exit(1);
 }


### PR DESCRIPTION
	- implement the -x for cp, to avoid copying across mount points