### PR TITLE
ksh NULL cleanup

### DIFF
--- a/bin/ksh/c_ksh.c
+++ b/bin/ksh/c_ksh.c
@@ -77,7 +77,7 @@ c_cd(char **wp)
 		 * we could try to find another substitution. For now
 		 * we don't
 		 */
-		if ((cp = strstr(current_wd, wp[0])) == (char *) 0) {
+		if ((cp = strstr(current_wd, wp[0])) == NULL) {
 			bi_errorf("bad substitution");
 			return 1;
 		}
@@ -99,7 +99,7 @@ c_cd(char **wp)
 	/* xp will have a bogus value after make_path() - set it to 0
 	 * so that if it's used, it will cause a dump
 	 */
-	xp = (char *) 0;
+	xp = NULL;
 
 	cdpath = str_val(global("CDPATH"));
 	do {
@@ -110,7 +110,7 @@ c_cd(char **wp)
 			simplify_path(Xstring(xs, xp));
 			rval = chdir(try = Xstring(xs, xp));
 		}
-	} while (rval < 0 && cdpath != (char *) 0);
+	} while (rval < 0 && cdpath != NULL);
 
 	if (rval < 0) {
 		if (cdnode)
@@ -133,7 +133,7 @@ c_cd(char **wp)
 		setstr(oldpwd_s, current_wd, KSH_RETURN_ERROR);
 
 	if (Xstring(xs, xp)[0] != '/') {
-		pwd = (char *) 0;
+		pwd = NULL;
 	} else
 	if (!physical || !(pwd = get_phys_path(Xstring(xs, xp))))
 		pwd = Xstring(xs, xp);
@@ -183,11 +183,11 @@ c_pwd(char **wp)
 		return 1;
 	}
 	p = current_wd[0] ? (physical ? get_phys_path(current_wd) : current_wd) :
-	    (char *) 0;
+	    NULL;
 	if (p && access(p, R_OK) < 0)
-		p = (char *) 0;
+		p = NULL;
 	if (!p) {
-		freep = p = ksh_get_wd((char *) 0, 0);
+		freep = p = ksh_get_wd(NULL, 0);
 		if (!p) {
 			bi_errorf("can't get current directory - %s",
 			    strerror(errno));
@@ -562,7 +562,7 @@ c_typeset(char **wp)
 		break;
 	}
 
-	fieldstr = basestr = (char *) 0;
+	fieldstr = basestr = NULL;
 	builtin_opt.flags |= GF_PLUSOPT;
 	/* at&t ksh seems to have 0-9 as options, which are multiplied
 	 * to get a number that is used with -L, -R, -Z or -i (eg, -1R2
@@ -882,7 +882,7 @@ c_alias(char **wp)
 	/* "hash -r" means reset all the tracked aliases.. */
 	if (rflag) {
 		static const char *const args[] = {
-			"unalias", "-ta", (const char *) 0
+			"unalias", "-ta", NULL
 		};
 
 		if (!tflag || *wp) {
@@ -946,8 +946,7 @@ c_alias(char **wp)
 				afree((void*)ap->val.s, APERM);
 			}
 			/* ignore values for -t (at&t ksh does this) */
-			newval = tflag ? search(alias, path, X_OK, (int *) 0) :
-			    val;
+			newval = tflag ? search(alias, path, X_OK, NULL) : val;
 			if (newval) {
 				ap->val.s = str_save(newval, APERM);
 				ap->flag |= ALLOC|ISSET;
@@ -1024,7 +1023,7 @@ c_let(char **wp)
 	int rv = 1;
 	long val;
 
-	if (wp[1] == (char *) 0) /* at&t ksh does this */
+	if (wp[1] == NULL) /* at&t ksh does this */
 		bi_errorf("no arguments");
 	else
 		for (wp++; *wp; wp++)
@@ -1063,7 +1062,7 @@ c_jobs(char **wp)
 		}
 	wp += builtin_opt.optind;
 	if (!*wp) {
-		if (j_jobs((char *) 0, flag, nflag))
+		if (j_jobs(NULL, flag, nflag))
 			rv = 1;
 	} else {
 		for (; *wp; wp++)
@@ -1129,7 +1128,7 @@ kill_fmt_entry(void *arg, int i, char *buf, int buflen)
 int
 c_kill(char **wp)
 {
-	Trap *t = (Trap *) 0;
+	Trap *t = NULL;
 	char *p;
 	int lflag = 0;
 	int i, n, rv, sig;
@@ -1276,12 +1275,12 @@ c_getopts(char **wp)
 		return 1;
 	}
 
-	if (e->loc->next == (struct block *) 0) {
+	if (e->loc->next == NULL) {
 		internal_errorf(0, "c_getopts: no argv");
 		return 1;
 	}
 	/* Which arguments are we parsing... */
-	if (*wp == (char *) 0)
+	if (*wp == NULL)
 		wp = e->loc->next->argv;
 	else
 		*--wp = e->loc->next->argv[0];
@@ -1296,7 +1295,7 @@ c_getopts(char **wp)
 		return 1;
 	}
 
-	user_opt.optarg = (char *) 0;
+	user_opt.optarg = NULL;
 	optc = ksh_getopt(wp, &user_opt, options);
 
 	if (optc >= 0 && optc != '?' && (user_opt.info & GI_PLUS)) {
@@ -1324,7 +1323,7 @@ c_getopts(char **wp)
 	/* Paranoia: ensure no bizarre results. */
 	if (voptarg->flag & INTEGER)
 	    typeset("OPTARG", 0, INTEGER, 0, 0);
-	if (user_opt.optarg == (char *) 0)
+	if (user_opt.optarg == NULL)
 		unset(voptarg, 0);
 	else
 		/* This can't fail (have cleared readonly/integer) */

--- a/bin/ksh/c_sh.c
+++ b/bin/ksh/c_sh.c
@@ -204,7 +204,7 @@ c_dot(char **wp)
 			;
 	} else {
 		argc = 0;
-		argv = (char **) 0;
+		argv = NULL;
 	}
 	i = include(file, argc, argv, 0);
 	if (i < 0) { /* should not happen */
@@ -223,8 +223,8 @@ c_wait(char **wp)
 	if (ksh_getopt(wp, &builtin_opt, null) == '?')
 		return 1;
 	wp += builtin_opt.optind;
-	if (*wp == (char *) 0) {
-		while (waitfor((char *) 0, &sig) >= 0)
+	if (*wp == NULL) {
+		while (waitfor(NULL, &sig) >= 0)
 			;
 		rv = sig;
 	} else {
@@ -351,7 +351,7 @@ c_read(char **wp)
 						/* set prompt in case this is
 						 * called from .profile or $ENV
 						 */
-						set_prompt(PS2, (Source *) 0);
+						set_prompt(PS2, NULL);
 						pprompt(prompt, 0);
 					}
 				} else if (c != EOF)
@@ -542,7 +542,7 @@ int
 c_brkcont(char **wp)
 {
 	int n, quit;
-	struct env *ep, *last_ep = (struct env *) 0;
+	struct env *ep, *last_ep = NULL;
 	char *arg;
 
 	if (ksh_getopt(wp, &builtin_opt, null) == '?')

--- a/bin/ksh/c_test.c
+++ b/bin/ksh/c_test.c
@@ -160,8 +160,7 @@ c_test(char **wp)
 				 */
 				if (!Flag(FPOSIX) && strcmp(opnd1, "-t") == 0)
 				    break;
-				res = (*te.eval)(&te, TO_STNZE, opnd1,
-				    (char *) 0, 1);
+				res = (*te.eval)(&te, TO_STNZE, opnd1, NULL, 1);
 				if (invert & 1)
 					res = !res;
 				return !res;
@@ -471,8 +470,7 @@ test_primary(Test_env *te, int do_eval)
 				return 0;
 			}
 
-			return (*te->eval)(te, op, opnd1, (const char *) 0,
-			    do_eval);
+			return (*te->eval)(te, op, opnd1, NULL, do_eval);
 		}
 	}
 	opnd1 = (*te->getopnd)(te, TO_NONOP, do_eval);
@@ -494,7 +492,7 @@ test_primary(Test_env *te, int do_eval)
 		(*te->error)(te, -1, "missing expression operator");
 		return 0;
 	}
-	return (*te->eval)(te, TO_STNZE, opnd1, (const char *) 0, do_eval);
+	return (*te->eval)(te, TO_STNZE, opnd1, NULL, do_eval);
 }
 
 /*
@@ -535,7 +533,7 @@ static const char *
 ptest_getopnd(Test_env *te, Test_op op, int do_eval)
 {
 	if (te->pos.wp >= te->wp_end)
-		return op == TO_FILTT ? "1" : (const char *) 0;
+		return op == TO_FILTT ? "1" : NULL;
 	return *te->pos.wp++;
 }
 
@@ -550,7 +548,7 @@ static void
 ptest_error(Test_env *te, int offset, const char *msg)
 {
 	const char *op = te->pos.wp + offset >= te->wp_end ?
-	    (const char *) 0 : te->pos.wp[offset];
+	    NULL : te->pos.wp[offset];
 
 	te->flags |= TEF_ERROR;
 	if (op)

--- a/bin/ksh/c_ulimit.c
+++ b/bin/ksh/c_ulimit.c
@@ -52,7 +52,7 @@ c_ulimit(char **wp)
 #ifdef RLIMIT_VMEM
 		{ "vmemory(kbytes)", RLIMIT_VMEM, 1024, 'v' },
 #endif /* RLIMIT_VMEM */
-		{ (char *) 0 }
+		{ NULL }
 	};
 	static char	options[4 + nitems(limits) * 2];
 	int		how = SOFT | HARD;

--- a/bin/ksh/edit.c
+++ b/bin/ksh/edit.c
@@ -319,11 +319,10 @@ x_print_expansions(int nwords, char *const *words, int is_command)
 
 		/* Special case for 1 match (prefix is whole word) */
 		if (nwords == 1)
-			prefix_len = x_basename(words[0], (char *) 0);
+			prefix_len = x_basename(words[0], NULL);
 		/* Any (non-trailing) slashes in non-common word suffixes? */
 		for (i = 0; i < nwords; i++)
-			if (x_basename(words[i] + prefix_len, (char *) 0) >
-			    prefix_len)
+			if (x_basename(words[i] + prefix_len, NULL) > prefix_len)
 				break;
 		/* All in same directory? */
 		if (i == nwords) {
@@ -333,7 +332,7 @@ x_print_expansions(int nwords, char *const *words, int is_command)
 			XPinit(l, nwords + 1);
 			for (i = 0; i < nwords; i++)
 				XPput(l, words[i] + prefix_len);
-			XPput(l, (char *) 0);
+			XPput(l, NULL);
 		}
 	}
 
@@ -471,7 +470,7 @@ x_command_glob(int flags, const char *str, int slen, char ***wordsp)
 	nwords = XPsize(w);
 
 	if (!nwords) {
-		*wordsp = (char **) 0;
+		*wordsp = NULL;
 		XPfree(w);
 		return 0;
 	}
@@ -488,7 +487,7 @@ x_command_glob(int flags, const char *str, int slen, char ***wordsp)
 		info = acalloc(nwords, sizeof(struct path_order_info), ATEMP);
 		for (i = 0; i < nwords; i++) {
 			info[i].word = words[i];
-			info[i].base = x_basename(words[i], (char *) 0);
+			info[i].base = x_basename(words[i], NULL);
 			if (!last_info || info[i].base != last_info->base ||
 			    strncmp(words[i], last_info->word, info[i].base) != 0) {
 				last_info = &info[i];
@@ -604,7 +603,7 @@ x_cf_glob(int flags, const char *buf, int buflen, int pos, int *startp,
 	nwords = (is_command ? x_command_glob : x_file_glob)(flags,
 	    buf + *startp, len, &words);
 	if (nwords == 0) {
-		*wordsp = (char **) 0;
+		*wordsp = NULL;
 		return 0;
 	}
 
@@ -627,7 +626,7 @@ add_glob(const char *str, int slen)
 	bool saw_slash = false;
 
 	if (slen < 0)
-		return (char *) 0;
+		return NULL;
 
 	toglob = str_nsave(str, slen + 1, ATEMP); /* + 1 for "*" */
 	toglob[slen] = '\0';
@@ -706,7 +705,7 @@ x_basename(const char *s, const char *se)
 {
 	const char *p;
 
-	if (se == (char *) 0)
+	if (se == NULL)
 		se = s + strlen(s);
 	if (s == se)
 		return 0;

--- a/bin/ksh/eval.c
+++ b/bin/ksh/eval.c
@@ -187,7 +187,7 @@ expand(char *cp,	/* input word */
 	doblank = 0;
 	make_magic = 0;
 	word = (f&DOBLANK) ? IFS_WS : IFS_WORD;
-	st_head.next = (SubType *) 0;
+	st_head.next = NULL;
 	st = &st_head;
 
 	while (1) {
@@ -294,7 +294,7 @@ expand(char *cp,	/* input word */
 
 						newst = (SubType *) alloc(
 						    sizeof(SubType), ATEMP);
-						newst->next = (SubType *) 0;
+						newst->next = NULL;
 						newst->prev = st;
 						st->next = newst;
 					}
@@ -704,7 +704,7 @@ varsub(Expand *xp, char *sp, char *word,
 	if (sp[0] == '\0')	/* Bad variable name */
 		return -1;
 
-	xp->var = (struct tbl *) 0;
+	xp->var = NULL;
 
 	/* ${#var}, string length or array size */
 	if (sp[0] == '#' && (c = sp[1]) != '\0') {
@@ -864,7 +864,7 @@ comsub(Expand *xp, char *cp)
 
 		if ((io->flag&IOTYPE) != IOREAD)
 			errorf("funny $() command: %s",
-			    snptreef((char *) 0, 32, "%R", io));
+			    snptreef(NULL, 32, "%R", io));
 		shf = shf_open(name = evalstr(io->name, DOTILDE), O_RDONLY, 0,
 			SHF_MAPHI|SHF_CLEXEC);
 		if (shf == NULL)
@@ -874,7 +874,7 @@ comsub(Expand *xp, char *cp)
 	} else {
 		int ofd1, pv[2];
 		openpipe(pv);
-		shf = shf_fdopen(pv[0], SHF_RD, (struct shf *) 0);
+		shf = shf_fdopen(pv[0], SHF_RD, NULL);
 		ofd1 = savefd(1);
 		if (pv[1] != 1) {
 			ksh_dup2(pv[1], 1, false);
@@ -1193,7 +1193,7 @@ maybe_expand_tilde(char *p, XString *dsp, char **dpp, int isassign)
 	}
 	*tp = '\0';
 	r = (p[0] == EOS || p[0] == CHAR || p[0] == CSUBST) ?
-	    tilde(Xstring(ts, tp)) : (char *) 0;
+	    tilde(Xstring(ts, tp)) : NULL;
 	Xfree(ts, tp);
 	if (r) {
 		while (*r) {
@@ -1229,7 +1229,7 @@ tilde(char *cp)
 		dp = homedir(cp);
 	/* If HOME, PWD or OLDPWD are not set, don't expand ~ */
 	if (dp == null)
-		dp = (char *) 0;
+		dp = NULL;
 	return dp;
 }
 
@@ -1274,7 +1274,7 @@ alt_expand(XPtrV *wp, char *start, char *exp_start, char *end, int fdo)
 
 	/* find matching close brace, if any */
 	if (p) {
-		comma = (char *) 0;
+		comma = NULL;
 		count = 1;
 		for (p += 2; *p && count; p++) {
 			if (ISMAGIC(*p)) {

--- a/bin/ksh/expr.c
+++ b/bin/ksh/expr.c
@@ -174,8 +174,8 @@ v_evaluate(struct tbl *vp, const char *expr, volatile int error_ok,
 	curstate.expression = curstate.tokp = expr;
 	curstate.noassign = 0;
 	curstate.arith = arith;
-	curstate.evaling = (struct tbl *) 0;
-	curstate.val = (struct tbl *) 0;
+	curstate.evaling = NULL;
+	curstate.val = NULL;
 
 	newenv(E_ERRH);
 	i = sigsetjmp(e->jbuf, 0);
@@ -203,7 +203,7 @@ v_evaluate(struct tbl *vp, const char *expr, volatile int error_ok,
 	v = intvar(es, evalexpr(es, MAX_PREC));
 
 	if (es->tok != END)
-		evalerr(es, ET_UNEXPECTED, (char *) 0);
+		evalerr(es, ET_UNEXPECTED, NULL);
 
 	if (vp->flag & INTEGER)
 		setint_v(vp, v, es->arith);
@@ -307,7 +307,7 @@ evalexpr(Expr_state *es, enum prec prec)
 			vl = es->val;
 			token(es);
 		} else {
-			evalerr(es, ET_UNEXPECTED, (char *) 0);
+			evalerr(es, ET_UNEXPECTED, NULL);
 			/* NOTREACHED */
 		}
 		if (es->tok == O_PLUSPLUS || es->tok == O_MINUSMINUS) {
@@ -588,7 +588,7 @@ intvar(Expr_state *es, struct tbl *vp)
 		vp->flag |= EXPRINEVAL;
 		v_evaluate(vq, str_val(vp), KSH_UNWIND_ERROR, es->arith);
 		vp->flag &= ~EXPRINEVAL;
-		es->evaling = (struct tbl *) 0;
+		es->evaling = NULL;
 	}
 	return vq;
 }

--- a/bin/ksh/io.c
+++ b/bin/ksh/io.c
@@ -75,7 +75,7 @@ bi_errorf(const char *fmt, ...)
 	 */
 	if ((builtin_flag & SPEC_BI) ||
 	    (Flag(FPOSIX) && (builtin_flag & KEEPASN))) {
-		builtin_argv0 = (char *) 0;
+		builtin_argv0 = NULL;
 		unwind(LERROR);
 	}
 }
@@ -424,12 +424,12 @@ maketemp(Area *ap, Temp_type type, struct temp **tlist)
 	len = strlen(dir) + 3 + 20 + 20 + 1;
 	tp = (struct temp *) alloc(sizeof(struct temp) + len, ap);
 	tp->name = path = (char *) &tp[1];
-	tp->shf = (struct shf *) 0;
+	tp->shf = NULL;
 	tp->type = type;
 	shf_snprintf(path, len, "%s/shXXXXXXXX", dir);
 	fd = mkstemp(path);
 	if (fd >= 0)
-		tp->shf = shf_fdopen(fd, SHF_WR, (struct shf *) 0);
+		tp->shf = shf_fdopen(fd, SHF_WR, NULL);
 	tp->pid = procpid;
 
 	tp->next = *tlist;

--- a/bin/ksh/jobs.c
+++ b/bin/ksh/jobs.c
@@ -101,7 +101,7 @@ static const char	*const lookup_msgs[] = {
 	"no such job",
 	"ambiguous",
 	"argument must be %job or process id",
-	(char *) 0
+	NULL
 };
 
 struct timeval	j_systime, j_usrtime;	/* user and system time of last j_waitjed job */
@@ -147,7 +147,7 @@ j_init(int mflagset)
 	child_max = CHILD_MAX; /* so syscon() isn't always being called */
 
 	sigemptyset(&sm_default);
-	sigprocmask(SIG_SETMASK, &sm_default, (sigset_t *) 0);
+	sigprocmask(SIG_SETMASK, &sm_default, NULL);
 
 	sigemptyset(&sm_sigchld);
 	sigaddset(&sm_sigchld, SIGCHLD);
@@ -162,7 +162,7 @@ j_init(int mflagset)
 	/* shl_j is used to do asynchronous notification (used in
 	 * an interrupt handler, so need a distinct shf)
 	 */
-	shl_j = shf_fdopen(2, SHF_WR, (struct shf *) 0);
+	shl_j = shf_fdopen(2, SHF_WR, NULL);
 
 	if (Flag(FMONITOR) || Flag(FTALKING)) {
 		int i;
@@ -248,7 +248,7 @@ j_exit(void)
 	Job	*j;
 	int	killed = 0;
 
-	for (j = job_list; j != (Job *) 0; j = j->next) {
+	for (j = job_list; j != NULL; j = j->next) {
 		if (j->ppid == procpid &&
 		    (j->state == PSTOPPED ||
 		    (j->state == PRUNNING &&
@@ -408,7 +408,7 @@ exchild(struct op *t, int flags, volatile int *xerrok,
 	sigprocmask(SIG_BLOCK, &sm_sigchld, &omask);
 
 	p = new_proc();
-	p->next = (Proc *) 0;
+	p->next = NULL;
 	p->state = PRUNNING;
 	p->status = 0;
 	p->pid = 0;
@@ -455,7 +455,7 @@ exchild(struct op *t, int flags, volatile int *xerrok,
 	if (i < 0) {
 		kill_job(j, SIGKILL);
 		remove_job(j, "fork failed");
-		sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+		sigprocmask(SIG_SETMASK, &omask, NULL);
 		errorf("cannot fork - try again");
 	}
 	ischild = i == 0;
@@ -495,7 +495,7 @@ exchild(struct op *t, int flags, volatile int *xerrok,
 		/* Do this before restoring signal */
 		if (flags & XCOPROC)
 			coproc_cleanup(false);
-		sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+		sigprocmask(SIG_SETMASK, &omask, NULL);
 		cleanup_parents_env();
 #ifdef JOBS
 		/* If FMONITOR or FTALKING is set, these signals are ignored,
@@ -567,7 +567,7 @@ exchild(struct op *t, int flags, volatile int *xerrok,
 			rv = j_waitj(j, JW_NONE, "jw:last proc");
 	}
 
-	sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	sigprocmask(SIG_SETMASK, &omask, NULL);
 
 	return rv;
 }
@@ -585,7 +585,7 @@ startlast(void)
 		last_job->flags |= JF_WAITING;
 		j_startjob(last_job);
 	}
-	sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	sigprocmask(SIG_SETMASK, &omask, NULL);
 }
 
 /* wait for last job: only used for `command` jobs */
@@ -604,13 +604,13 @@ waitlast(void)
 			warningf(true, "waitlast: no last job");
 		else
 			internal_errorf(0, "waitlast: not started");
-		sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+		sigprocmask(SIG_SETMASK, &omask, NULL);
 		return 125; /* not so arbitrary, non-zero value */
 	}
 
 	rv = j_waitj(j, JW_NONE, "jw:waitlast");
 
-	sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	sigprocmask(SIG_SETMASK, &omask, NULL);
 
 	return rv;
 }
@@ -629,7 +629,7 @@ waitfor(const char *cp, int *sigp)
 
 	*sigp = 0;
 
-	if (cp == (char *) 0) {
+	if (cp == NULL) {
 		/* wait for an unspecified job - always returns 0, so
 		 * don't have to worry about exited/signaled jobs
 		 */
@@ -638,18 +638,18 @@ waitfor(const char *cp, int *sigp)
 			if (j->ppid == procpid && j->state == PRUNNING)
 				break;
 		if (!j) {
-			sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+			sigprocmask(SIG_SETMASK, &omask, NULL);
 			return -1;
 		}
 	} else if ((j = j_lookup(cp, &ecode))) {
 		/* don't report normal job completion */
 		flags &= ~JW_ASYNCNOTIFY;
 		if (j->ppid != procpid) {
-			sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+			sigprocmask(SIG_SETMASK, &omask, NULL);
 			return -1;
 		}
 	} else {
-		sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+		sigprocmask(SIG_SETMASK, &omask, NULL);
 		if (ecode != JL_NOSUCH)
 			bi_errorf("%s: %s", cp, lookup_msgs[ecode]);
 		return -1;
@@ -658,7 +658,7 @@ waitfor(const char *cp, int *sigp)
 	/* at&t ksh will wait for stopped jobs - we don't */
 	rv = j_waitj(j, flags, "jw:waitfor");
 
-	sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	sigprocmask(SIG_SETMASK, &omask, NULL);
 
 	if (rv < 0) /* we were interrupted */
 		*sigp = 128 + -rv;
@@ -677,8 +677,8 @@ j_kill(const char *cp, int sig)
 
 	sigprocmask(SIG_BLOCK, &sm_sigchld, &omask);
 
-	if ((j = j_lookup(cp, &ecode)) == (Job *) 0) {
-		sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	if ((j = j_lookup(cp, &ecode)) == NULL) {
+		sigprocmask(SIG_SETMASK, &omask, NULL);
 		bi_errorf("%s: %s", cp, lookup_msgs[ecode]);
 		return 1;
 	}
@@ -699,7 +699,7 @@ j_kill(const char *cp, int sig)
 		}
 	}
 
-	sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	sigprocmask(SIG_SETMASK, &omask, NULL);
 
 	return rv;
 }
@@ -718,14 +718,14 @@ j_resume(const char *cp, int bg)
 
 	sigprocmask(SIG_BLOCK, &sm_sigchld, &omask);
 
-	if ((j = j_lookup(cp, &ecode)) == (Job *) 0) {
-		sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	if ((j = j_lookup(cp, &ecode)) == NULL) {
+		sigprocmask(SIG_SETMASK, &omask, NULL);
 		bi_errorf("%s: %s", cp, lookup_msgs[ecode]);
 		return 1;
 	}
 
 	if (j->pgrp == 0) {
-		sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+		sigprocmask(SIG_SETMASK, &omask, NULL);
 		bi_errorf("job not job-controlled");
 		return 1;
 	}
@@ -734,7 +734,7 @@ j_resume(const char *cp, int bg)
 		shprintf("[%d] ", j->job);
 
 	running = 0;
-	for (p = j->proc_list; p != (Proc *) 0; p = p->next) {
+	for (p = j->proc_list; p != NULL; p = p->next) {
 		if (p->state == PSTOPPED) {
 			p->state = PRUNNING;
 			p->status = 0;
@@ -762,8 +762,7 @@ j_resume(const char *cp, int bg)
 			    j->saved_ttypgrp : j->pgrp) < 0) {
 				if (j->flags & JF_SAVEDTTY)
 					tcsetattr(tty_fd, TCSADRAIN, &tty_state);
-				sigprocmask(SIG_SETMASK, &omask,
-				    (sigset_t *) 0);
+				sigprocmask(SIG_SETMASK, &omask, NULL);
 				bi_errorf("1st tcsetpgrp(%d, %d) failed: %s",
 				    tty_fd,
 				    (int) ((j->flags & JF_SAVEDTTYPGRP) ?
@@ -776,7 +775,7 @@ j_resume(const char *cp, int bg)
 		j->flags |= JF_FG;
 		j->flags &= ~JF_KNOWN;
 		if (j == async_job)
-			async_job = (Job *) 0;
+			async_job = NULL;
 	}
 
 	if (j->state == PRUNNING && killpg(j->pgrp, SIGCONT) < 0) {
@@ -795,7 +794,7 @@ j_resume(const char *cp, int bg)
 			}
 # endif /* JOBS */
 		}
-		sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+		sigprocmask(SIG_SETMASK, &omask, NULL);
 		bi_errorf("cannot continue job %s: %s",
 		    cp, strerror(err));
 		return 1;
@@ -808,7 +807,7 @@ j_resume(const char *cp, int bg)
 # endif /* JOBS */
 		rv = j_waitj(j, JW_NONE, "jw:resume");
 	}
-	sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	sigprocmask(SIG_SETMASK, &omask, NULL);
 	return rv;
 }
 #endif /* JOBS */
@@ -820,7 +819,7 @@ j_stopped_running(void)
 	Job	*j;
 	int	which = 0;
 
-	for (j = job_list; j != (Job *) 0; j = j->next) {
+	for (j = job_list; j != NULL; j = j->next) {
 #ifdef JOBS
 		if (j->ppid == procpid && j->state == PSTOPPED)
 			which |= 1;
@@ -851,7 +850,7 @@ j_njobs(void)
 	for (j = job_list; j; j = j->next)
 		nj++;
 
-	sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	sigprocmask(SIG_SETMASK, &omask, NULL);
 	return nj;
 }
 
@@ -875,8 +874,8 @@ j_jobs(const char *cp, int slp,
 	if (cp) {
 		int	ecode;
 
-		if ((j = j_lookup(cp, &ecode)) == (Job *) 0) {
-			sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+		if ((j = j_lookup(cp, &ecode)) == NULL) {
+			sigprocmask(SIG_SETMASK, &omask, NULL);
 			bi_errorf("%s: %s", cp, lookup_msgs[ecode]);
 			return 1;
 		}
@@ -899,7 +898,7 @@ j_jobs(const char *cp, int slp,
 		if (j->flags & JF_REMOVE)
 			remove_job(j, "jobs");
 	}
-	sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	sigprocmask(SIG_SETMASK, &omask, NULL);
 	return 0;
 }
 
@@ -928,7 +927,7 @@ j_notify(void)
 			remove_job(j, "notify");
 	}
 	shf_flush(shl_out);
-	sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	sigprocmask(SIG_SETMASK, &omask, NULL);
 }
 
 /* Return pid of last process in last asynchronous job */
@@ -942,7 +941,7 @@ j_async(void)
 	if (async_job)
 		async_job->flags |= JF_KNOWN;
 
-	sigprocmask(SIG_SETMASK, &omask, (sigset_t *) 0);
+	sigprocmask(SIG_SETMASK, &omask, NULL);
 
 	return async_pid;
 }
@@ -965,7 +964,7 @@ j_set_async(Job *j)
 	async_job = j;
 	async_pid = j->last_proc->pid;
 	while (nzombie > child_max) {
-		oldest = (Job *) 0;
+		oldest = NULL;
 		for (jl = job_list; jl; jl = jl->next)
 			if (jl != async_job && (jl->flags & JF_ZOMBIE) &&
 			    (!oldest || jl->age < oldest->age))
@@ -1169,12 +1168,12 @@ j_sigchld(int sig)
 		getrusage(RUSAGE_CHILDREN, &ru1);
 
 		/* find job and process structures for this pid */
-		for (j = job_list; j != (Job *) 0; j = j->next)
-			for (p = j->proc_list; p != (Proc *) 0; p = p->next)
+		for (j = job_list; j != NULL; j = j->next)
+			for (p = j->proc_list; p != NULL; p = p->next)
 				if (p->pid == pid)
 					goto found;
 found:
-		if (j == (Job *) 0) {
+		if (j == NULL) {
 			/* Can occur if process has kids, then execs shell
 			warningf(true, "bad process waited for (pid = %d)",
 				pid);
@@ -1228,7 +1227,7 @@ check_job(Job *j)
 	}
 
 	jstate = PRUNNING;
-	for (p=j->proc_list; p != (Proc *) 0; p = p->next) {
+	for (p=j->proc_list; p != NULL; p = p->next) {
 		if (p->state == PRUNNING)
 			return;	/* some processes still running */
 		if (p->state > jstate)
@@ -1257,7 +1256,7 @@ check_job(Job *j)
 		 * (at least, this is what ksh93d thinks)
 		 */
 		if (coproc.job == j) {
-			coproc.job = (void *) 0;
+			coproc.job = NULL;
 			/* XXX would be nice to get the closes out of here
 			 * so they aren't done in the signal handler.
 			 * Would mean a check in coproc_getfd() to
@@ -1346,7 +1345,7 @@ j_print(Job *j, int how, struct shf *shf)
 	else if (j == job_list->next)
 		jobchar = '-';
 
-	for (p = j->proc_list; p != (Proc *) 0;) {
+	for (p = j->proc_list; p != NULL;) {
 		coredumped = 0;
 		switch (p->state) {
 		case PRUNNING:
@@ -1435,54 +1434,54 @@ j_lookup(const char *cp, int *ecodep)
 	if (digit(*cp)) {
 		job = atoi(cp);
 		/* Look for last_proc->pid (what $! returns) first... */
-		for (j = job_list; j != (Job *) 0; j = j->next)
+		for (j = job_list; j != NULL; j = j->next)
 			if (j->last_proc && j->last_proc->pid == job)
 				return j;
 		/* ...then look for process group (this is non-POSIX),
 		 * but should not break anything (so FPOSIX isn't used).
 		 */
-		for (j = job_list; j != (Job *) 0; j = j->next)
+		for (j = job_list; j != NULL; j = j->next)
 			if (j->pgrp && j->pgrp == job)
 				return j;
 		if (ecodep)
 			*ecodep = JL_NOSUCH;
-		return (Job *) 0;
+		return NULL;
 	}
 	if (*cp != '%') {
 		if (ecodep)
 			*ecodep = JL_INVALID;
-		return (Job *) 0;
+		return NULL;
 	}
 	switch (*++cp) {
 	case '\0': /* non-standard */
 	case '+':
 	case '%':
-		if (job_list != (Job *) 0)
+		if (job_list != NULL)
 			return job_list;
 		break;
 
 	case '-':
-		if (job_list != (Job *) 0 && job_list->next)
+		if (job_list != NULL && job_list->next)
 			return job_list->next;
 		break;
 
 	case '0': case '1': case '2': case '3': case '4':
 	case '5': case '6': case '7': case '8': case '9':
 		job = atoi(cp);
-		for (j = job_list; j != (Job *) 0; j = j->next)
+		for (j = job_list; j != NULL; j = j->next)
 			if (j->job == job)
 				return j;
 		break;
 
 	case '?':		/* %?string */
-		last_match = (Job *) 0;
-		for (j = job_list; j != (Job *) 0; j = j->next)
-			for (p = j->proc_list; p != (Proc *) 0; p = p->next)
-				if (strstr(p->command, cp+1) != (char *) 0) {
+		last_match = NULL;
+		for (j = job_list; j != NULL; j = j->next)
+			for (p = j->proc_list; p != NULL; p = p->next)
+				if (strstr(p->command, cp+1) != NULL) {
 					if (last_match) {
 						if (ecodep)
 							*ecodep = JL_AMBIG;
-						return (Job *) 0;
+						return NULL;
 					}
 					last_match = j;
 				}
@@ -1492,13 +1491,13 @@ j_lookup(const char *cp, int *ecodep)
 
 	default:		/* %string */
 		len = strlen(cp);
-		last_match = (Job *) 0;
-		for (j = job_list; j != (Job *) 0; j = j->next)
+		last_match = NULL;
+		for (j = job_list; j != NULL; j = j->next)
 			if (strncmp(cp, j->proc_list->command, len) == 0) {
 				if (last_match) {
 					if (ecodep)
 						*ecodep = JL_AMBIG;
-					return (Job *) 0;
+					return NULL;
 				}
 				last_match = j;
 			}
@@ -1508,7 +1507,7 @@ j_lookup(const char *cp, int *ecodep)
 	}
 	if (ecodep)
 		*ecodep = JL_NOSUCH;
-	return (Job *) 0;
+	return NULL;
 }
 
 static Job	*free_jobs;
@@ -1524,7 +1523,7 @@ new_job(void)
 	int	i;
 	Job	*newj, *j;
 
-	if (free_jobs != (Job *) 0) {
+	if (free_jobs != NULL) {
 		newj = free_jobs;
 		free_jobs = free_jobs->next;
 	} else
@@ -1534,7 +1533,7 @@ new_job(void)
 	for (i = 1; ; i++) {
 		for (j = job_list; j && j->job != i; j = j->next)
 			;
-		if (j == (Job *) 0)
+		if (j == NULL)
 			break;
 	}
 	newj->job = i;
@@ -1551,7 +1550,7 @@ new_proc(void)
 {
 	Proc	*p;
 
-	if (free_procs != (Proc *) 0) {
+	if (free_procs != NULL) {
 		p = free_procs;
 		free_procs = free_procs->next;
 	} else
@@ -1573,7 +1572,7 @@ remove_job(Job *j, const char *where)
 
 	prev = &job_list;
 	curr = *prev;
-	for (; curr != (Job *) 0 && curr != j; prev = &curr->next, curr = *prev)
+	for (; curr != NULL && curr != j; prev = &curr->next, curr = *prev)
 		;
 	if (curr != j) {
 		internal_errorf(0, "remove_job: job not found (%s)", where);
@@ -1582,7 +1581,7 @@ remove_job(Job *j, const char *where)
 	*prev = curr->next;
 
 	/* free up proc structures */
-	for (p = j->proc_list; p != (Proc *) 0; ) {
+	for (p = j->proc_list; p != NULL; ) {
 		tmp = p;
 		p = p->next;
 		tmp->next = free_procs;
@@ -1595,9 +1594,9 @@ remove_job(Job *j, const char *where)
 	free_jobs = j;
 
 	if (j == last_job)
-		last_job = (Job *) 0;
+		last_job = NULL;
 	if (j == async_job)
-		async_job = (Job *) 0;
+		async_job = NULL;
 }
 
 /* put j in a particular location (taking it out job_list if it is there
@@ -1646,7 +1645,7 @@ kill_job(Job *j, int sig)
 	Proc	*p;
 	int	rval = 0;
 
-	for (p = j->proc_list; p != (Proc *) 0; p = p->next)
+	for (p = j->proc_list; p != NULL; p = p->next)
 		if (p->pid != 0)
 			if (kill(p->pid, sig) < 0)
 				rval = -1;

--- a/bin/ksh/lex.c
+++ b/bin/ksh/lex.c
@@ -728,9 +728,9 @@ Done:
 				ungetsc(c2);
 		}
 
-		iop->name = (char *) 0;
-		iop->delim = (char *) 0;
-		iop->heredoc = (char *) 0;
+		iop->name = NULL;
+		iop->delim = NULL;
+		iop->heredoc = NULL;
 		Xfree(ws, wp);	/* free word */
 		yylval.iop = iop;
 		return REDIR;
@@ -1135,7 +1135,7 @@ getsc_line(Source *s)
 #endif /* HISTORY */
 	}
 	if (interactive)
-		set_prompt(PS2, (Source *) 0);
+		set_prompt(PS2, NULL);
 }
 
 static char *

--- a/bin/ksh/main.c
+++ b/bin/ksh/main.c
@@ -103,7 +103,7 @@ main(int argc, char *argv[])
 	/* make sure argv[] is sane */
 	if (!*argv) {
 		static const char *empty_argv[] = {
-			"ksh", (char *) 0
+			"ksh", NULL
 		};
 
 		argv = (char **) empty_argv;
@@ -150,7 +150,7 @@ main(int argc, char *argv[])
 
 	def_path = _PATH_DEFPATH;
 	{
-		size_t len = confstr(_CS_PATH, (char *) 0, 0);
+		size_t len = confstr(_CS_PATH, NULL, 0);
 		char *new;
 
 		if (len > 0) {
@@ -236,7 +236,7 @@ main(int argc, char *argv[])
 		    stat(pwd, &s_pwd) < 0 || stat(".", &s_dot) < 0 ||
 		    s_pwd.st_dev != s_dot.st_dev ||
 		    s_pwd.st_ino != s_dot.st_ino)
-			pwdx = (char *) 0;
+			pwdx = NULL;
 		set_current_wd(pwdx);
 		if (current_wd[0])
 			simplify_path(current_wd);
@@ -281,7 +281,7 @@ main(int argc, char *argv[])
 
 	/* this to note if monitor is set on command line (see below) */
 	Flag(FMONITOR) = 127;
-	argi = parse_args(argv, OF_CMDLINE, (int *) 0);
+	argi = parse_args(argv, OF_CMDLINE, NULL);
 	if (argi < 0)
 		exit(1);
 
@@ -304,14 +304,13 @@ main(int argc, char *argv[])
 		Flag(FSTDIN) = 1;
 		s = pushs(SSTDIN, ATEMP);
 		s->file = "<stdin>";
-		s->u.shf = shf_fdopen(0, SHF_RD | can_seek(0),
-		    (struct shf *) 0);
+		s->u.shf = shf_fdopen(0, SHF_RD | can_seek(0), NULL);
 		if (isatty(0) && isatty(2)) {
 			Flag(FTALKING) = Flag(FTALKING_I) = 1;
 			/* The following only if isatty(0) */
 			s->flags |= SF_TTY;
 			s->u.shf->flags |= SHF_INTERRUPT;
-			s->file = (char *) 0;
+			s->file = NULL;
 		}
 	}
 
@@ -352,14 +351,13 @@ main(int argc, char *argv[])
 		warningf(false, "Cannot determine current working directory");
 
 	if (Flag(FLOGIN)) {
-		include(KSH_SYSTEM_PROFILE, 0, (char **) 0, 1);
+		include(KSH_SYSTEM_PROFILE, 0, NULL, 1);
 		if (!Flag(FPRIVILEGED))
-			include(substitute("$HOME/.profile", 0), 0,
-			    (char **) 0, 1);
+			include(substitute("$HOME/.profile", 0), 0, NULL, 1);
 	}
 
 	if (Flag(FPRIVILEGED))
-		include("/etc/suid_profile", 0, (char **) 0, 1);
+		include("/etc/suid_profile", 0, NULL, 1);
 	else if (Flag(FTALKING)) {
 		char *env_file;
 
@@ -373,7 +371,7 @@ main(int argc, char *argv[])
 #endif /* DEFAULT_ENV */
 		env_file = substitute(env_file, DOTILDE);
 		if (*env_file != '\0')
-			include(env_file, 0, (char **) 0, 1);
+			include(env_file, 0, NULL, 1);
 	}
 
 	if (is_restricted(argv[0]) || is_restricted(str_val(global("SHELL"))))
@@ -382,7 +380,7 @@ main(int argc, char *argv[])
 		static const char *const restr_com[] = {
 			"typeset", "-r", "PATH",
 			"ENV", "SHELL",
-			(char *) 0
+			NULL
 		};
 		shcomexec((char **) restr_com);
 		/* After typeset command... */
@@ -432,7 +430,7 @@ include(const char *name, int argc, char **argv, int intr_ok)
 		old_argv = e->loc->argv;
 		old_argc = e->loc->argc;
 	} else {
-		old_argv = (char **) 0;
+		old_argv = NULL;
 		old_argc = 0;
 	}
 	newenv(E_INCL);
@@ -738,10 +736,10 @@ cleanup_parents_env(void)
 				if (ep->savefd[fd] > 0)
 					close(ep->savefd[fd]);
 			afree(ep->savefd, &ep->area);
-			ep->savefd = (short *) 0;
+			ep->savefd = NULL;
 		}
 	}
-	e->oenv = (struct env *) 0;
+	e->oenv = NULL;
 }
 
 /* Called just before an execve cleanup stuff temporary files */

--- a/bin/ksh/misc.c
+++ b/bin/ksh/misc.c
@@ -121,7 +121,7 @@ const struct option options[] = {
 	{ "braceexpand",  0,		OF_ANY }, /* non-standard */
 #endif
 	{ "bgnice",	  0,		OF_ANY },
-	{ (char *) 0,	'c',	    OF_CMDLINE },
+	{ NULL,	'c',	    OF_CMDLINE },
 	{ "csh-history",  0,		OF_ANY }, /* non-standard */
 #ifdef EMACS
 	{ "emacs",	  0,		OF_ANY },
@@ -139,7 +139,7 @@ const struct option options[] = {
 #ifdef JOBS
 	{ "monitor",	'm',		OF_ANY },
 #else /* JOBS */
-	{ (char *) 0,	'm',		     0 }, /* so FMONITOR not ifdef'd */
+	{ NULL,	'm',		     0 }, /* so FMONITOR not ifdef'd */
 #endif /* JOBS */
 	{ "noclobber",	'C',		OF_ANY },
 	{ "noexec",	'n',		OF_ANY },
@@ -169,7 +169,7 @@ const struct option options[] = {
 	/* Anonymous flags: used internally by shell only
 	 * (not visible to user)
 	 */
-	{ (char *) 0,	0,		OF_INTERNAL }, /* FTALKING_I */
+	{ NULL,	0,		OF_INTERNAL }, /* FTALKING_I */
 };
 
 /*
@@ -324,7 +324,7 @@ parse_args(char **argv,
 	static char cmd_opts[nitems(options) + 3]; /* o:\0 */
 	static char set_opts[nitems(options) + 5]; /* Ao;s\0 */
 	char *opts;
-	char *array = (char *) 0;
+	char *array = NULL;
 	Getopt go;
 	int i, optc, set, sortargs = 0, arrayset = 0;
 
@@ -370,7 +370,7 @@ parse_args(char **argv,
 			break;
 
 		case 'o':
-			if (go.optarg == (char *) 0) {
+			if (go.optarg == NULL) {
 				/* lone -o: print options
 				 *
 				 * Note that on the command line, -o requires
@@ -809,7 +809,7 @@ pat_scan(const unsigned char *p, const unsigned char *pe, int match_sep)
 		if ((*p & 0x80) && strchr("*+?@! ", *p & 0x7f))
 			nest++;
 	}
-	return (const unsigned char *) 0;
+	return NULL;
 }
 
 /*
@@ -834,7 +834,7 @@ void
 ksh_getopt_reset(Getopt *go, int flags)
 {
 	go->optind = 1;
-	go->optarg = (char *) 0;
+	go->optarg = NULL;
 	go->p = 0;
 	go->flags = flags;
 	go->info = 0;
@@ -882,7 +882,7 @@ ksh_getopt(char **argv, Getopt *go, const char *options)
 			go->info |= GI_MINUSMINUS;
 			return -1;
 		}
-		if (arg == (char *) 0 ||
+		if (arg == NULL ||
 		    ((flag != '-' ) && /* neither a - nor a + (if + allowed) */
 		    (!(go->flags & GF_PLUSOPT) || flag != '+')) ||
 		    (c = arg[1]) == '\0') {
@@ -919,7 +919,7 @@ ksh_getopt(char **argv, Getopt *go, const char *options)
 		else if (argv[go->optind])
 			go->optarg = argv[go->optind++];
 		else if (*o == ';')
-			go->optarg = (char *) 0;
+			go->optarg = NULL;
 		else {
 			if (options[0] == ':') {
 				go->buf[0] = c;
@@ -949,14 +949,14 @@ ksh_getopt(char **argv, Getopt *go, const char *options)
 				go->optarg = argv[go->optind - 1] + go->p;
 				go->p = 0;
 			} else
-				go->optarg = (char *) 0;
+				go->optarg = NULL;
 		} else {
 			if (argv[go->optind] && (digit(argv[go->optind][0]) ||
 			    !strcmp(argv[go->optind], "unlimited"))) {
 				go->optarg = argv[go->optind++];
 				go->p = 0;
 			} else
-				go->optarg = (char *) 0;
+				go->optarg = NULL;
 		}
 	}
 	return c;

--- a/bin/ksh/path.c
+++ b/bin/ksh/path.c
@@ -67,7 +67,7 @@ make_path(const char *cwd, const char *file,
 			for (pend = plist; *pend && *pend != ':'; pend++)
 				;
 			plen = pend - plist;
-			*cdpathp = *pend ? ++pend : (char *) 0;
+			*cdpathp = *pend ? ++pend : NULL;
 		}
 
 		if ((use_cdpath == 0 || !plen || plist[0] != '/') &&
@@ -95,7 +95,7 @@ make_path(const char *cwd, const char *file,
 	memcpy(xp, file, len);
 
 	if (!use_cdpath)
-		*cdpathp = (char *) 0;
+		*cdpathp = NULL;
 
 	return rval;
 }
@@ -177,7 +177,7 @@ set_current_wd(char *path)
 	int len;
 	char *p = path;
 
-	if (!p && !(p = ksh_get_wd((char *) 0, 0)))
+	if (!p && !(p = ksh_get_wd(NULL, 0)))
 		p = null;
 
 	len = strlen(p) + 1;
@@ -200,7 +200,7 @@ get_phys_path(const char *path)
 	xp = do_phys_path(&xs, xp, path);
 
 	if (!xp)
-		return (char *) 0;
+		return NULL;
 
 	if (Xlength(xs, xp) == 0)
 		Xput(xs, xp, '/');
@@ -246,7 +246,7 @@ do_phys_path(XString *xsp, char *xp, const char *path)
 		if (llen < 0) {
 			/* EINVAL means it wasn't a symlink... */
 			if (errno != EINVAL)
-				return (char *) 0;
+				return NULL;
 			continue;
 		}
 		lbuf[llen] = '\0';
@@ -255,7 +255,7 @@ do_phys_path(XString *xsp, char *xp, const char *path)
 		xp = lbuf[0] == '/' ? Xstring(*xsp, xp) :
 		    Xrestpos(*xsp, xp, savepos);
 		if (!(xp = do_phys_path(xsp, xp, lbuf)))
-			return (char *) 0;
+			return NULL;
 	}
 	return xp;
 }

--- a/bin/ksh/shf.c
+++ b/bin/ksh/shf.c
@@ -100,7 +100,7 @@ shf_fdopen(int fd, int sflags, struct shf *shf)
 			shf->buf = (unsigned char *) alloc(bsize, ATEMP);
 			sflags |= SHF_ALLOCB;
 		} else
-			shf->buf = (unsigned char *) 0;
+			shf->buf = NULL;
 	} else {
 		shf = (struct shf *) alloc(sizeof(struct shf) + bsize, ATEMP);
 		shf->buf = (unsigned char *) &shf[1];
@@ -469,7 +469,7 @@ shf_getse(char *buf, int bsize, struct shf *shf)
 		internal_errorf(1, "shf_getse: flags %x", shf->flags);
 
 	if (bsize <= 0)
-		return (char *) 0;
+		return NULL;
 
 	--bsize;	/* save room for null */
 	do {
@@ -697,7 +697,7 @@ shf_smprintf(const char *fmt, ...)
 	struct shf shf;
 	va_list args;
 
-	shf_sopen((char *) 0, 0, SHF_WR|SHF_DYNAMIC, &shf);
+	shf_sopen(NULL, 0, SHF_WR|SHF_DYNAMIC, &shf);
 	va_start(args, fmt);
 	shf_vfprintf(&shf, fmt, args);
 	va_end(args);

--- a/bin/ksh/syn.c
+++ b/bin/ksh/syn.c
@@ -66,7 +66,7 @@ yyparse(void)
 	if (c == 0 && !outtree)
 		outtree = newtp(TEOF);
 	else if (c != '\n' && c != 0)
-		syntaxerr((char *) 0);
+		syntaxerr(NULL);
 }
 
 static struct op *
@@ -78,7 +78,7 @@ pipeline(int cf)
 	if (t != NULL) {
 		while (token(0) == '|') {
 			if ((p = get_command(CONTIN)) == NULL)
-				syntaxerr((char *) 0);
+				syntaxerr(NULL);
 			if (tl == NULL)
 				t = tl = block(TPIPE, t, p, NULL);
 			else
@@ -99,7 +99,7 @@ andor(void)
 	if (t != NULL) {
 		while ((c = token(0)) == LOGAND || c == LOGOR) {
 			if ((p = pipeline(CONTIN)) == NULL)
-				syntaxerr((char *) 0);
+				syntaxerr(NULL);
 			t = block(c == LOGAND? TAND: TOR, t, p, NULL);
 		}
 		REJECT;
@@ -171,7 +171,7 @@ static void
 musthave(int c, int cf)
 {
 	if ((token(cf)) != c)
-		syntaxerr((char *) 0);
+		syntaxerr(NULL);
 }
 
 static struct op *
@@ -253,7 +253,7 @@ get_command(int cf)
 				/* Must be a function */
 				if (iopn != 0 || XPsize(args) != 1 ||
 				    XPsize(vars) != 0)
-					syntaxerr((char *) 0);
+					syntaxerr(NULL);
 				ACCEPT;
 				/*(*/
 				musthave(')', 0);
@@ -354,8 +354,8 @@ get_command(int cf)
 	case BANG:
 		syniocf &= ~(KEYWORD|ALIAS);
 		t = pipeline(0);
-		if (t == (struct op *) 0)
-			syntaxerr((char *) 0);
+		if (t == NULL)
+			syntaxerr(NULL);
 		t = block(TBANG, NULL, t, NULL);
 		break;
 
@@ -421,7 +421,7 @@ dogroup(void)
 	else if (c == '{')
 		c = '}';
 	else
-		syntaxerr((char *) 0);
+		syntaxerr(NULL);
 	list = c_list(true);
 	musthave(c, KEYWORD|ALIAS);
 	return list;
@@ -436,7 +436,7 @@ thenpart(void)
 	t = newtp(0);
 	t->left = c_list(true);
 	if (t->left == NULL)
-		syntaxerr((char *) 0);
+		syntaxerr(NULL);
 	t->right = elsepart();
 	return (t);
 }
@@ -449,7 +449,7 @@ elsepart(void)
 	switch (token(KEYWORD|ALIAS|VARASN)) {
 	case ELSE:
 		if ((t = c_list(true)) == NULL)
-			syntaxerr((char *) 0);
+			syntaxerr(NULL);
 		return (t);
 
 	case ELIF:
@@ -477,7 +477,7 @@ caselist(void)
 	else if (c == '{')
 		c = '}';
 	else
-		syntaxerr((char *) 0);
+		syntaxerr(NULL);
 	t = tl = NULL;
 	while ((tpeek(CONTIN|KEYWORD|ESACONLY)) != c) { /* no ALIAS here */
 		struct op *tc = casepart(c);
@@ -554,7 +554,7 @@ function_body(char *name,
 
 	old_func_parse = e->flags & EF_FUNC_PARSE;
 	e->flags |= EF_FUNC_PARSE;
-	if ((t->left = get_command(CONTIN)) == (struct op *) 0) {
+	if ((t->left = get_command(CONTIN)) == NULL) {
 		/*
 		 * Probably something like foo() followed by eof or ;.
 		 * This is accepted by sh and ksh88.
@@ -567,9 +567,9 @@ function_body(char *name,
 		t->left->args[0][0] = CHAR;
 		t->left->args[0][1] = ':';
 		t->left->args[0][2] = EOS;
-		t->left->args[1] = (char *) 0;
+		t->left->args[1] = NULL;
 		t->left->vars = (char **) alloc(sizeof(char *), ATEMP);
-		t->left->vars[0] = (char *) 0;
+		t->left->vars[0] = NULL;
 		t->left->lineno = 1;
 	}
 	if (!old_func_parse)
@@ -594,7 +594,7 @@ wordlist(void)
 	while ((c = token(0)) == LWORD)
 		XPput(args, yylval.cp);
 	if (c != '\n' && c != ';')
-		syntaxerr((char *) 0);
+		syntaxerr(NULL);
 	XPput(args, NULL);
 	return (char **) XPclose(args);
 }
@@ -695,7 +695,7 @@ syntaxerr(const char *what)
 		/* NOTREACHED */
 
 	case LWORD:
-		s = snptreef((char *) 0, 32, "%S", yylval.cp);
+		s = snptreef(NULL, 32, "%S", yylval.cp);
 		break;
 
 	case REDIR:
@@ -820,7 +820,7 @@ dbtestp_isa(Test_env *te, Test_meta meta)
 {
 	int c = tpeek(ARRAYVAR | (meta == TM_BINOP ? 0 : CONTIN));
 	int uqword = 0;
-	char *save = (char *) 0;
+	char *save = NULL;
 	int ret = 0;
 
 	/* unquoted word? */
@@ -863,7 +863,7 @@ dbtestp_getopnd(Test_env *te, Test_op op, int do_eval)
 	int c = tpeek(ARRAYVAR);
 
 	if (c != LWORD)
-		return (const char *) 0;
+		return NULL;
 
 	ACCEPT;
 	XPput(*te->pos.av, yylval.cp);

--- a/bin/ksh/trap.c
+++ b/bin/ksh/trap.c
@@ -198,7 +198,7 @@ runtraps(int flag)
 		fatal_trap = 0;
 	for (p = sigtraps, i = NSIG+1; --i >= 0; p++)
 		if (p->set && (!flag ||
-		    ((p->flags & flag) && p->trap == (char *) 0)))
+		    ((p->flags & flag) && p->trap == NULL)))
 			runtrap(p);
 }
 
@@ -211,7 +211,7 @@ runtrap(Trap *p)
 	int	old_changed = 0;
 
 	p->set = 0;
-	if (trapstr == (char *) 0) { /* SIG_DFL */
+	if (trapstr == NULL) { /* SIG_DFL */
 		if (p->flags & TF_FATAL) {
 			/* eg, SIGHUP */
 			exstat = 128 + i;
@@ -229,7 +229,7 @@ runtrap(Trap *p)
 	if (i == SIGEXIT_ || i == SIGERR_) {	/* avoid recursion on these */
 		old_changed = p->flags & TF_CHANGED;
 		p->flags &= ~TF_CHANGED;
-		p->trap = (char *) 0;
+		p->trap = NULL;
 	}
 	oexstat = exstat;
 	/* Note: trapstr is fully parsed before anything is executed, thus
@@ -260,7 +260,7 @@ cleartraps(void)
 	for (i = NSIG+1, p = sigtraps; --i >= 0; p++) {
 		p->set = 0;
 		if ((p->flags & TF_USER_SET) && (p->trap && p->trap[0]))
-			settrap(p, (char *) 0);
+			settrap(p, NULL);
 	}
 }
 
@@ -387,7 +387,7 @@ setsig(Trap *p, sig_t f, int flags)
 		sigemptyset(&sigact.sa_mask);
 		sigact.sa_flags = 0 /* interruptible */;
 		sigact.sa_handler = f;
-		sigaction(p->signal, &sigact, (struct sigaction *) 0);
+		sigaction(p->signal, &sigact, NULL);
 	}
 
 	return 1;

--- a/bin/ksh/tree.c
+++ b/bin/ksh/tree.c
@@ -563,7 +563,7 @@ wdstrip(const char *wp)
 	struct shf shf;
 	int c;
 
-	shf_sopen((char *) 0, 32, SHF_WR | SHF_DYNAMIC, &shf);
+	shf_sopen(NULL, 32, SHF_WR | SHF_DYNAMIC, &shf);
 
 	/* problems:
 	 *	`...` -> $(...)
@@ -639,11 +639,11 @@ iocopy(struct ioword **iow, Area *ap)
 		q = (struct ioword *) alloc(sizeof(*p), ap);
 		ior[i] = q;
 		*q = *p;
-		if (p->name != (char *) 0)
+		if (p->name != NULL)
 			q->name = wdcopy(p->name, ap);
-		if (p->delim != (char *) 0)
+		if (p->delim != NULL)
 			q->delim = wdcopy(p->delim, ap);
-		if (p->heredoc != (char *) 0)
+		if (p->heredoc != NULL)
 			q->heredoc = str_save(p->heredoc, ap);
 	}
 	ior[i] = NULL;

--- a/bin/ksh/var.c
+++ b/bin/ksh/var.c
@@ -108,7 +108,7 @@ initvar(void)
 		{ "SECONDS",		V_SECONDS },
 		{ "TMOUT",		V_TMOUT },
 		{ "LINENO",		V_LINENO },
-		{ (char *) 0,	0 }
+		{ NULL,	0 }
 	};
 	int i;
 	struct tbl *tp;
@@ -260,7 +260,7 @@ local(const char *n, bool copy)
 	vp = ktenter(&l->vars, n, h);
 	if (copy && !(vp->flag & DEFINED)) {
 		struct block *ll = l;
-		struct tbl *vq = (struct tbl *) 0;
+		struct tbl *vq = NULL;
 
 		while ((ll = ll->next) && !(vq = ktsearch(&ll->vars, n, h)))
 			;
@@ -669,11 +669,10 @@ typeset(const char *var, Tflag set, Tflag clr, int field, int base)
 			if (fake_assign) {
 				if (t->flag & INTEGER) {
 					s = str_val(t);
-					free_me = (char *) 0;
+					free_me = NULL;
 				} else {
 					s = t->val.s + t->type;
-					free_me = (t->flag & ALLOC) ? t->val.s :
-					    (char *) 0;
+					free_me = (t->flag & ALLOC) ? t->val.s : NULL;
 				}
 				t->flag &= ~ALLOC;
 			}
@@ -753,7 +752,7 @@ unset(struct tbl *vp, int array_ref)
 				afree((void *) tmp->val.s, tmp->areap);
 			afree(tmp, tmp->areap);
 		}
-		vp->u.array = (struct tbl *) 0;
+		vp->u.array = NULL;
 	}
 	/* If foo[0] is being unset, the remainder of the array is kept... */
 	vp->flag &= SPECIAL | (array_ref ? ARRAY|DEFINED : 0);
@@ -974,7 +973,7 @@ setspec(struct tbl *vp)
 	case V_TMPDIR:
 		if (tmpdir) {
 			afree(tmpdir, APERM);
-			tmpdir = (char *) 0;
+			tmpdir = NULL;
 		}
 		/* Use tmpdir iff it is an absolute path, is writable and
 		 * searchable and is a directory...
@@ -1064,14 +1063,14 @@ unsetspec(struct tbl *vp)
 		/* should not become unspecial */
 		if (tmpdir) {
 			afree(tmpdir, APERM);
-			tmpdir = (char *) 0;
+			tmpdir = NULL;
 		}
 		break;
 	case V_MAIL:
-		mbset((char *) 0);
+		mbset(NULL);
 		break;
 	case V_MAILPATH:
-		mpset((char *) 0);
+		mpset(NULL);
 		break;
 	case V_LINENO:
 	case V_MAILCHECK:	/* at&t ksh leaves previous value in place */

--- a/bin/ksh/vi.c
+++ b/bin/ksh/vi.c
@@ -1930,7 +1930,7 @@ expand_word(int command)
 
 	nwords = x_cf_glob(XCF_COMMAND_FILE|XCF_FULLPATH,
 	    es->cbuf, es->linelen, es->cursor,
-	    &start, &end, &words, (int *) 0);
+	    &start, &end, &words, NULL);
 	if (nwords == 0) {
 		vi_error();
 		return -1;
@@ -2016,12 +2016,12 @@ complete_word(int command, int count)
 		 */
 		if (is_command) {
 			match = words[count] +
-			    x_basename(words[count], (char *) 0);
+			    x_basename(words[count], NULL);
 			/* If more than one possible match, use full path */
 			for (i = 0; i < nwords; i++)
 				if (i != count &&
 				    strcmp(words[i] + x_basename(words[i],
-				    (char *) 0), match) == 0) {
+				    NULL), match) == 0) {
 					match = words[count];
 					break;
 				}


### PR DESCRIPTION
Much of ksh was using (T *)0 as a NULL value, so cleanup and use
NULL as it eases reading. No binary change.

I took the opportunity to unwrap some previously too long line to fit in the 80ch limit.

Discussed with natano.