### PR TITLE
Switch to ntp servers from bitrig.pool.ntp.org

### DIFF
--- a/etc/ntpd.conf
+++ b/etc/ntpd.conf
@@ -3,7 +3,7 @@
 # Addresses to listen on (ntpd does not listen by default)
 #listen on *
 
-# use a servers from Bitrig Vendor Pool Time Servers
+# use servers from Bitrig Vendor Pool Time Servers
 # see http://support.ntp.org/bin/view/Servers/NTPPoolServers
 servers 0.bitrig.pool.ntp.org
 servers 1.bitrig.pool.ntp.org

--- a/etc/ntpd.conf
+++ b/etc/ntpd.conf
@@ -3,9 +3,12 @@
 # Addresses to listen on (ntpd does not listen by default)
 #listen on *
 
-# use a random selection of NTP Pool Time Servers
+# use a servers from Bitrig Vendor Pool Time Servers
 # see http://support.ntp.org/bin/view/Servers/NTPPoolServers
-servers pool.ntp.org
+servers 0.bitrig.pool.ntp.org
+servers 1.bitrig.pool.ntp.org
+servers 2.bitrig.pool.ntp.org
+servers 3.bitrig.pool.ntp.org
 
 # use all detected timedelta sensors
 sensor *


### PR DESCRIPTION
This changes the default ntpd config to use the bitrig vendor pool for ntp updates.  Of course we need to decide if we want to do that, but I don't see any real reason not to.