### PR TITLE
Apply fix to LCP echoes not sent

### DIFF
--- a/sys/net/if_spppsubr.c
+++ b/sys/net/if_spppsubr.c
@@ -4094,7 +4094,7 @@ sppp_keepalive(void *dummy)
 		}
 		if (sp->pp_alivecnt < MAXALIVECNT)
 			++sp->pp_alivecnt;
-		else if (sp->pp_phase >= PHASE_AUTHENTICATE) {
+		if (sp->pp_phase >= PHASE_AUTHENTICATE) {
 			u_int32_t nmagic = htonl(sp->lcp.magic);
 			sp->lcp.echoid = ++sp->pp_seq;
 			sppp_cp_send (sp, PPP_LCP, ECHO_REQ,


### PR DESCRIPTION
Bogus "else" remaining from Cisco old code cleanup.
Re-porting fix by sthen@ from OpenBSD tree.

Reference:
http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/net/if_spppsubr.c?annotate=1.151
